### PR TITLE
Document contributor setup and env template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,12 +1,32 @@
-# This file lives in the Grinta repo only — it is loaded before any workspace import.
-# Optional: ``-p <repo>/.env`` can override keys per client repo (e.g. API keys).
-# File logs: ``<Grinta>/logs/workspaces/<name>__<hash>/`` (one folder per PROJECT_ROOT).
-# LOG_TO_FILE and DEBUG_LLM default to true in code; override if needed:
+# Grinta environment variables (copy to `.env` beside your active settings root).
+#
+# Settings layout
+# ---------------
+# - Source checkout: `<repo>/settings.json` + `<repo>/.env` (default)
+# - Installed CLI (pipx / Homebrew / Scoop): `~/.grinta/settings.json` + `~/.grinta/.env`
+# - Override root: set `APP_ROOT` to any writable directory; both files live there.
+#
+# `settings.json` should reference secrets as `${LLM_API_KEY}`; put the real value
+# in `.env` or your shell environment. `LLM_API_KEY` wins over `llm_api_key` in JSON.
+#
+# Optional per-project overrides: `grinta -p /path/to/repo` pins PROJECT_ROOT; you
+# can keep a project-specific `.env` for client-repo API keys when needed.
+#
+# Logging (defaults are set in code; uncomment to override)
 # LOG_TO_FILE=false
 # DEBUG_LLM=false
-# Primary LLM secret (recommended). Overrides settings.json ``llm_api_key`` when set.
+#
+# Primary LLM secret (recommended)
 # LLM_API_KEY=your_key_here
+#
+# Provider-specific keys (also auto-detected by `grinta init` when set in the shell)
+# OPENAI_API_KEY=sk-...
+# ANTHROPIC_API_KEY=sk-ant-...
 # GEMINI_API_KEY=your_gemini_key
+# GROQ_API_KEY=gsk_...
 # OPENROUTER_API_KEY=your_openrouter_key
-# GITHUB_PERSONAL_ACCESS_TOKEN=ghp_...  # optional: PAT for GitHub MCP (repo scope)
-# EXA_API_KEY=...  # optional: Exa MCP (https://mcp.exa.ai/mcp) — higher limits / required on some accounts
+# VERCEL_API_KEY=vck_...
+#
+# Optional integrations
+# GITHUB_PERSONAL_ACCESS_TOKEN=ghp_...  # GitHub MCP (repo scope)
+# EXA_API_KEY=...  # Exa MCP (https://mcp.exa.ai/mcp)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,38 @@ cd Grinta-Coding-Agent
 # Install dependencies
 python scripts/bootstrap_env.py dev-test
 
+# First-run LLM setup (interactive; writes settings.json + .env)
+uv run python -m backend.cli.entry init
+
 # Start the CLI
 uv run python -m backend.cli.entry
 ```
+
+On Windows PowerShell you can use the convenience wrapper instead:
+
+```powershell
+.\START_HERE.ps1
+```
+
+That script syncs `dev-test` dependencies, checks local model servers, runs `init`
+when `settings.json` is missing, then launches the CLI.
+
+### Local configuration (source checkout)
+
+- **`settings.json`** at the repository root holds non-secret defaults (`llm_model`,
+  `llm_provider`, `${LLM_API_KEY}` placeholder).
+- **`.env`** beside `settings.json` stores the real `LLM_API_KEY` (copy from
+  [`.env.template`](.env.template); never commit secrets).
+- **`APP_ROOT`** overrides where `settings.json` is resolved when you need an
+  isolated config directory (for example smoke tests or multiple profiles).
+- Installed runs (`pipx`, Homebrew, Scoop) use `~/.grinta/settings.json` instead
+  of the repo root unless `APP_ROOT` is set.
+
+Launching `grinta` or `uv run python -m backend.cli.entry` without a configured
+key runs the same shared setup wizard as `grinta init`. Prefer `init` for an
+explicit first-time setup step.
+
+See also [docs/QUICK_START.md](docs/QUICK_START.md) and [docs/USER_GUIDE.md](docs/USER_GUIDE.md).
 
 ## How to Contribute
 


### PR DESCRIPTION
## Summary
- Add `grinta init` and local configuration guidance to CONTRIBUTING.md, including repo vs `~/.grinta` vs `APP_ROOT` settings layout and the Windows `START_HERE.ps1` path.
- Expand `.env.template` with settings-root documentation, `LLM_API_KEY` precedence notes, and common provider key examples.

## Test plan
- [x] Docs-only change; reviewed for accuracy against current onboarding flow
- [ ] Confirm links render in GitHub preview

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Document local configuration and first-run setup workflow for contributors and update environment template guidance for LLM configuration.

Documentation:
- Add contributor onboarding steps for running the interactive init flow, using the Windows wrapper script, and understanding local configuration locations and overrides.
- Clarify where settings and secrets should be stored across source checkouts and installed runs, including use of APP_ROOT and ~/.grinta.
- Expand the environment template documentation for LLM API key usage and configuration precedence.