### PR TITLE
stabilize prompt cache prefixes across turns

### DIFF
--- a/backend/context/memory/conversation_memory.py
+++ b/backend/context/memory/conversation_memory.py
@@ -36,6 +36,7 @@ from backend.context.prompt.message_formatting import (
 )
 from backend.context.prompt.prompt_assembly import process_recall_observation
 from backend.context.prompt.prompt_window import event_fingerprint
+from backend.context.prompt.turn_context import wrap_turn_context
 from backend.context.tool_call_tracker import (
     filter_unmatched_tool_calls,
     flush_resolved_tool_calls,
@@ -59,7 +60,7 @@ from backend.ledger.observation.reject import UserRejectObservation
 from backend.ledger.observation.status import StatusObservation
 from backend.utils.prompt import PromptManager
 
-_MAX_SYSTEM_CONTEXT_SUMMARY_CHARS = 2000
+_MAX_TURN_CONTEXT_SUMMARY_CHARS = 2000
 _PROMPT_RENDERER_VERSION = 'context-memory-render-v1'
 _DEFAULT_RENDER_CACHE_MAX = 1024
 
@@ -887,41 +888,35 @@ class ContextMemory:
             messages.insert(0, messages.pop(first_idx))
         return messages
 
-    def _inject_context_summary_into_system(self, messages: list[Message]) -> None:
-        """Append a bounded context summary to the leading system message."""
+    @staticmethod
+    def _insert_before_last_user(messages: list[Message], message: Message) -> None:
+        insert_at = len(messages)
+        for index in range(len(messages) - 1, -1, -1):
+            if messages[index].role == 'user':
+                insert_at = index
+                break
+        messages.insert(insert_at, message)
+
+    def _insert_context_summary_before_last_user(
+        self, messages: list[Message]
+    ) -> None:
+        """Insert a bounded context snapshot beside the current user turn."""
         context_summary = self.get_context_summary()
         if not context_summary or not messages:
             return
-        sys_msg = messages[0]
-        if sys_msg.role != 'system':
-            return
         summary = context_summary
-        if len(summary) > _MAX_SYSTEM_CONTEXT_SUMMARY_CHARS:
+        if len(summary) > _MAX_TURN_CONTEXT_SUMMARY_CHARS:
             logger.warning(
-                'Context summary truncated for system prompt integrity: %d -> %d chars',
+                'Context summary truncated for turn-context integrity: %d -> %d chars',
                 len(summary),
-                _MAX_SYSTEM_CONTEXT_SUMMARY_CHARS,
+                _MAX_TURN_CONTEXT_SUMMARY_CHARS,
             )
             summary = (
-                summary[:_MAX_SYSTEM_CONTEXT_SUMMARY_CHARS].rstrip()
+                summary[:_MAX_TURN_CONTEXT_SUMMARY_CHARS].rstrip()
                 + '\n[Context summary truncated for prompt integrity]'
             )
-        for content in sys_msg.content:
-            if is_text_content(content):
-                content.text += f'\n\n{summary}'
-                break
-
-    @staticmethod
-    def _first_user_message_leading_text(messages: list[Message]) -> str | None:
-        existing = messages[1] if len(messages) > 1 else None
-        if existing is None or existing.role not in ('user', 'system'):
-            return None
-        text_parts = [
-            content.text for content in existing.content if is_text_content(content)
-        ]
-        if not text_parts:
-            return None
-        return text_parts[0].strip()
+        block = wrap_turn_context(summary, kind='session-summary')
+        self._insert_before_last_user(messages, message_with_text('system', block))
 
     def _build_mcp_user_addendum_text(self) -> str | None:
         builder = getattr(self.prompt_manager, 'get_mcp_user_addendum', None)
@@ -940,8 +935,11 @@ class ContextMemory:
             return None
         return addendum or None
 
-    def _ensure_mcp_user_addendum(self, messages: list[Message]) -> None:
-        """Insert the MCP catalogue as a leading user message when configured."""
+    def _insert_mcp_addendum_before_last_user(
+        self,
+        messages: list[Message],
+    ) -> None:
+        """Insert the current MCP catalogue beside the current user turn."""
         if not messages or messages[0].role != 'system':
             return
 
@@ -949,11 +947,8 @@ class ContextMemory:
         if not addendum:
             return
 
-        leading = self._first_user_message_leading_text(messages)
-        if leading == addendum:
-            return
-
-        messages.insert(1, message_with_text('system', addendum))
+        block = wrap_turn_context(addendum, kind='mcp-catalog')
+        self._insert_before_last_user(messages, message_with_text('system', block))
 
     def _dedupe_system_messages(self, messages: list[Message]) -> list[Message]:
         """Return list with leading message plus non-system messages only."""
@@ -962,13 +957,13 @@ class ContextMemory:
         return [messages[0]] + [m for m in messages[1:] if m.role != 'system']
 
     def _normalize_system_messages(self, messages: list[Message]) -> list[Message]:
-        """Ensure a single leading system prompt and drop duplicates."""
+        """Keep behavior static up front and data snapshots near the active turn."""
         if not messages:
             return messages
         self._ensure_leading_system_message(messages)
-        self._inject_context_summary_into_system(messages)
         messages[:] = self._dedupe_system_messages(messages)
-        self._ensure_mcp_user_addendum(messages)
+        self._insert_mcp_addendum_before_last_user(messages)
+        self._insert_context_summary_before_last_user(messages)
         return messages
 
     def _process_action(

--- a/backend/context/prompt/turn_context.py
+++ b/backend/context/prompt/turn_context.py
@@ -1,0 +1,106 @@
+"""Markers for application-owned context that varies between agent turns."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+TURN_CONTEXT_START = '<GRINTA_TURN_CONTEXT'
+TURN_CONTEXT_END = '</GRINTA_TURN_CONTEXT>'
+
+_KIND_PATTERN = re.compile(r'[^a-z0-9_-]+')
+
+
+def is_turn_context_text(text: object) -> bool:
+    """Return whether *text* is an application-owned per-turn context block."""
+    return isinstance(text, str) and text.lstrip().startswith(TURN_CONTEXT_START)
+
+
+def wrap_turn_context(text: object, *, kind: str) -> str:
+    """Wrap dynamic context without changing an already wrapped block.
+
+    The marker lets prompt assembly preserve each dynamic snapshot beside the
+    user turn it originally accompanied. Provider adapters can also distinguish
+    these blocks from the stable leading system instruction.
+    """
+    value = '' if text is None else str(text)
+    if is_turn_context_text(value):
+        return value
+    safe_kind = _KIND_PATTERN.sub('-', kind.strip().lower()).strip('-') or 'context'
+    return (
+        f'<GRINTA_TURN_CONTEXT kind="{safe_kind}">\n'
+        f'{value.strip()}\n'
+        f'{TURN_CONTEXT_END}'
+    )
+
+
+def _content_to_text(content: object) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return '' if content is None else str(content)
+    parts: list[str] = []
+    for item in content:
+        if isinstance(item, str):
+            parts.append(item)
+        elif isinstance(item, dict) and item.get('text'):
+            parts.append(str(item['text']))
+    return '\n'.join(parts)
+
+
+def _prepend_context(message: dict[str, Any], context: str) -> dict[str, Any]:
+    merged = dict(message)
+    content = message.get('content', '')
+    if isinstance(content, list):
+        merged['content'] = [{'type': 'text', 'text': context}, *content]
+    else:
+        text = content if isinstance(content, str) else str(content or '')
+        merged['content'] = f'{context}\n\n{text}' if text else context
+    return merged
+
+
+def split_stable_system_prefix(
+    messages: list[dict[str, Any]],
+) -> tuple[list[str], list[dict[str, Any]]]:
+    """Split stable leading instructions and merge late context into its user turn.
+
+    Provider APIs that expose only one top-level system instruction cannot keep
+    mid-conversation system roles. Merging app-owned context into the following
+    user turn preserves ordering without producing malformed consecutive user
+    entries in providers that expect alternating chat roles.
+    """
+    stable_system: list[str] = []
+    body: list[dict[str, Any]] = []
+    pending_context: list[str] = []
+    leading = True
+
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = message.get('role')
+        text = _content_to_text(message.get('content')).strip()
+        if leading and role == 'system' and not is_turn_context_text(text):
+            if text:
+                stable_system.append(text)
+            continue
+
+        leading = False
+        if role == 'system':
+            if text:
+                pending_context.append(
+                    wrap_turn_context(text, kind='provider-system')
+                )
+            continue
+
+        if pending_context:
+            context = '\n\n'.join(pending_context)
+            pending_context.clear()
+            if role == 'user':
+                body.append(_prepend_context(message, context))
+                continue
+            body.append({'role': 'user', 'content': context})
+        body.append(message)
+
+    if pending_context:
+        body.append({'role': 'user', 'content': '\n\n'.join(pending_context)})
+    return stable_system, body

--- a/backend/core/config/agent_config.py
+++ b/backend/core/config/agent_config.py
@@ -393,8 +393,8 @@ class AgentConfig(BaseModel, metaclass=CanonicalModelMetaclass):
         default=DEFAULT_AGENT_MERGE_CONTROL_SYSTEM_INTO_PRIMARY,
         description=(
             'Append APP control/status text to the first system message instead of '
-            'inserting a second system message (some providers handle a single system '
-            'message better)'
+            'inserting a late turn-context message. This compatibility option reduces '
+            'prompt-cache reuse because the leading prefix changes each turn.'
         ),
     )
     max_consecutive_errors: int = Field(

--- a/backend/engine/llm_message_serializer.py
+++ b/backend/engine/llm_message_serializer.py
@@ -26,6 +26,12 @@ def _content_list_has_images(content_val: list[Any]) -> bool:
     )
 
 
+def _content_list_has_cache_control(content_val: list[Any]) -> bool:
+    return any(
+        isinstance(item, dict) and 'cache_control' in item for item in content_val
+    )
+
+
 def _extract_text_chunks(msg: Message) -> list[str]:
     fallback_lines: list[str] = []
     for chunk in getattr(msg, 'content', []) or []:
@@ -74,7 +80,10 @@ def _serialize_single_message(msg: Message) -> dict:
         msg.vision_enabled = True
     raw = _serialize_message_with_fallback(msg)
     content_val = raw.get('content', '')
-    if isinstance(content_val, list) and _content_list_has_images(content_val):
+    if isinstance(content_val, list) and (
+        _content_list_has_images(content_val)
+        or _content_list_has_cache_control(content_val)
+    ):
         return raw
     if isinstance(content_val, list):
         raw['content'] = _flatten_content_list(content_val)

--- a/backend/engine/memory_prompt_cache.py
+++ b/backend/engine/memory_prompt_cache.py
@@ -24,6 +24,7 @@ def apply_prompt_cache_hints(messages: list[Message], llm_config: object) -> Non
     for item in first_message.content:
         if isinstance(item, TextContent):
             item.cache_prompt = True
+            first_message.cache_enabled = True
             break
 
     # Stable intermediate anchors: mark the 4th and 8th user messages
@@ -39,6 +40,7 @@ def apply_prompt_cache_hints(messages: list[Message], llm_config: object) -> Non
             for item in msg.content:
                 if isinstance(item, TextContent):
                     item.cache_prompt = True
+                    msg.cache_enabled = True
                     break
         user_msg_idx += 1
         if user_msg_idx > max(_STABLE_USER_CACHE_POSITIONS):
@@ -50,5 +52,6 @@ def apply_prompt_cache_hints(messages: list[Message], llm_config: object) -> Non
         for item in message.content:
             if isinstance(item, TextContent):
                 item.cache_prompt = True
+                message.cache_enabled = True
                 break
         break

--- a/backend/engine/planner.py
+++ b/backend/engine/planner.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 from typing import TYPE_CHECKING, Any
 
+from backend.context.prompt.turn_context import (
+    is_turn_context_text,
+    wrap_turn_context,
+)
 from backend.core.constants import (
     DEFAULT_AGENT_DEBUGGER_ENABLED,
     DEFAULT_AGENT_LSP_QUERY_ENABLED,
@@ -53,7 +58,11 @@ _INJECTED_MSG_MARKERS = (
     '<REPOSITORY_INSTRUCTIONS>',
     '<CONVERSATION_INSTRUCTIONS>',
     '<EXTRA_INFO>',
+    '<GRINTA_TURN_CONTEXT',
 )
+
+_TURN_CONTEXT_STATE_KEY = '_prompt_turn_context_v1'
+_MAX_RECORDED_TURN_CONTEXTS = 64
 
 
 def _maybe_log_prompt_metrics(messages: list) -> None:
@@ -121,6 +130,8 @@ def _message_contains(message: dict[str, Any], marker: str) -> bool:
 
 def _is_static_prompt_message(message: dict[str, Any]) -> bool:
     role = message.get('role')
+    if is_turn_context_text(_message_text(message)):
+        return False
     if role == 'system':
         return True
     if role != 'user':
@@ -430,25 +441,238 @@ class OrchestratorPlanner:
                 )
                 break
 
+    @staticmethod
+    def _user_message_fingerprint(message: dict[str, Any]) -> str:
+        return hashlib.sha256(_message_text(message).encode('utf-8')).hexdigest()
+
+    @staticmethod
+    def _turn_context_payload(state: State) -> dict[str, Any]:
+        extra = getattr(state, 'extra_data', None)
+        if not isinstance(extra, dict):
+            return {}
+        payload = extra.get(_TURN_CONTEXT_STATE_KEY)
+        return payload if isinstance(payload, dict) else {}
+
+    @staticmethod
+    def _record_lookup(
+        messages: list,
+    ) -> tuple[dict[int, tuple[str, int]], int | None]:
+        """Map each user-message index to a stable text fingerprint + occurrence."""
+        identities: dict[int, tuple[str, int]] = {}
+        occurrences: dict[str, int] = {}
+        last_user_index: int | None = None
+        for index, message in enumerate(messages):
+            if not isinstance(message, dict) or message.get('role') != 'user':
+                continue
+            fingerprint = OrchestratorPlanner._user_message_fingerprint(message)
+            occurrence = occurrences.get(fingerprint, 0)
+            occurrences[fingerprint] = occurrence + 1
+            identities[index] = (fingerprint, occurrence)
+            last_user_index = index
+        return identities, last_user_index
+
+    def _restore_prior_turn_context(
+        self,
+        messages: list,
+        state: State,
+    ) -> tuple[list, bool]:
+        """Restore app context beside retained historical user turns.
+
+        ContextMemory rebuilds messages from ledger events, while planner-only
+        control blocks are intentionally not ledger events. Keeping a compact,
+        content-addressed snapshot in State makes subsequent provider requests
+        append-only for every retained turn.
+        """
+        payload = self._turn_context_payload(state)
+        pool = payload.get('blocks')
+        turns = payload.get('turns')
+        if not isinstance(pool, dict) or not isinstance(turns, list):
+            return list(messages), False
+
+        records: dict[tuple[str, int], list[str]] = {}
+        for record in turns:
+            if not isinstance(record, dict):
+                continue
+            fingerprint = record.get('user_fingerprint')
+            occurrence = record.get('occurrence')
+            block_ids = record.get('block_ids')
+            if (
+                not isinstance(fingerprint, str)
+                or not isinstance(occurrence, int)
+                or not isinstance(block_ids, list)
+            ):
+                continue
+            blocks = [pool.get(block_id) for block_id in block_ids]
+            records[(fingerprint, occurrence)] = [
+                block
+                for block in blocks
+                if isinstance(block, str) and is_turn_context_text(block)
+            ]
+
+        identities, last_user_index = self._record_lookup(messages)
+        if last_user_index is None:
+            return list(messages), False
+        current_identity = identities[last_user_index]
+        current_turn_restored = current_identity in records
+
+        restored: list = []
+        for index, message in enumerate(messages):
+            identity = identities.get(index)
+            if (
+                identity is not None
+                and identity in records
+            ):
+                # Replace, rather than duplicate, any snapshots supplied by a
+                # future ContextMemory implementation.
+                while (
+                    restored
+                    and isinstance(restored[-1], dict)
+                    and restored[-1].get('role') == 'system'
+                    and is_turn_context_text(_message_text(restored[-1]))
+                ):
+                    restored.pop()
+                restored.extend(
+                    {'role': 'system', 'content': block}
+                    for block in records.get(identity, [])
+                )
+            restored.append(message)
+        return restored, current_turn_restored
+
+    def _record_current_turn_context(self, messages: list, state: State) -> None:
+        identities, last_user_index = self._record_lookup(messages)
+        if last_user_index is None:
+            return
+
+        blocks: list[str] = []
+        index = last_user_index - 1
+        while index >= 0:
+            message = messages[index]
+            if (
+                not isinstance(message, dict)
+                or message.get('role') != 'system'
+                or not is_turn_context_text(_message_text(message))
+            ):
+                break
+            blocks.append(_message_text(message))
+            index -= 1
+        blocks.reverse()
+        if not blocks:
+            return
+
+        identity = identities[last_user_index]
+        payload = self._turn_context_payload(state)
+        raw_pool = payload.get('blocks')
+        raw_turns = payload.get('turns')
+        pool = dict(raw_pool) if isinstance(raw_pool, dict) else {}
+        turns = (
+            [item for item in raw_turns if isinstance(item, dict)]
+            if isinstance(raw_turns, list)
+            else []
+        )
+
+        block_ids: list[str] = []
+        for block in blocks:
+            block_id = hashlib.sha256(block.encode('utf-8')).hexdigest()
+            pool[block_id] = block
+            block_ids.append(block_id)
+
+        fingerprint, occurrence = identity
+        record = {
+            'user_fingerprint': fingerprint,
+            'occurrence': occurrence,
+            'block_ids': block_ids,
+        }
+        turns = [
+            item
+            for item in turns
+            if (
+                item.get('user_fingerprint'),
+                item.get('occurrence'),
+            )
+            != identity
+        ]
+        turns.append(record)
+        turns = turns[-_MAX_RECORDED_TURN_CONTEXTS:]
+        referenced_ids: set[str] = set()
+        for item in turns:
+            saved_ids = item.get('block_ids')
+            if isinstance(saved_ids, list):
+                referenced_ids.update(
+                    block_id for block_id in saved_ids if isinstance(block_id, str)
+                )
+        new_payload = {
+            'blocks': {
+                block_id: text
+                for block_id, text in pool.items()
+                if block_id in referenced_ids and isinstance(text, str)
+            },
+            'turns': turns,
+        }
+
+        extra = getattr(state, 'extra_data', None)
+        if isinstance(extra, dict):
+            extra[_TURN_CONTEXT_STATE_KEY] = new_payload
+        setter = getattr(state, 'set_extra', None)
+        if callable(setter):
+            try:
+                setter(
+                    _TURN_CONTEXT_STATE_KEY,
+                    new_payload,
+                    source='OrchestratorPlanner',
+                )
+            except Exception:
+                logger.debug('Failed to persist turn context snapshots', exc_info=True)
+
+    @staticmethod
+    def _build_prompt_cache_variant(messages: list, tools: object) -> str:
+        """Fingerprint only the stable provider prefix and active tool schemas."""
+        leading_system: list[str] = []
+        for message in messages:
+            if not isinstance(message, dict) or message.get('role') != 'system':
+                break
+            text = _message_text(message)
+            if is_turn_context_text(text):
+                break
+            leading_system.append(text)
+        payload = json.dumps(
+            {
+                'leading_system': leading_system,
+                'tools': tools if isinstance(tools, list) else [],
+            },
+            sort_keys=True,
+            separators=(',', ':'),
+            default=str,
+        )
+        return hashlib.sha256(payload.encode('utf-8')).hexdigest()[:24]
+
     def build_llm_params(
         self,
         messages: list,
         state: State,
         tools: list[ChatCompletionToolParam],
     ) -> dict:
+        messages, continuing_turn = self._restore_prior_turn_context(messages, state)
         tool_choice = self._determine_tool_choice(messages, state)
         mode = self._active_mode_for_state(state)
-        messages = self._inject_turn_status(messages, state)
-        messages = self._inject_coding_preflight(messages, state, mode)
-        messages = self._inject_repo_map(messages, mode)
+        if continuing_turn:
+            messages = self._inject_continuation_directive(messages, state)
+        else:
+            messages = self._inject_turn_status(messages, state)
+            messages = self._inject_coding_preflight(messages, state, mode)
+            messages = self._inject_repo_map(messages, mode)
         tools = self._filter_tools_for_mode(tools, mode)
-        messages = self._inject_mode_instructions(messages, state, mode)
+        if not continuing_turn:
+            messages = self._inject_mode_instructions(messages, state, mode)
         _maybe_log_prompt_metrics(messages)
         self._warn_if_degraded_emergency_prompt(messages)
         self._log_debug_mode_info(messages, state, mode)
 
         params: dict[str, Any] = {'messages': messages, 'stream': True}
         params = self._configure_tool_routing(params, tools, messages, tool_choice)
+        self._record_current_turn_context(params['messages'], state)
+        params['_prompt_cache_variant'] = self._build_prompt_cache_variant(
+            params['messages'], params.get('tools', [])
+        )
         params['extra_body'] = {
             'metadata': state.to_llm_metadata(
                 model_name=(self._llm.config.model or '').strip() or 'unknown',
@@ -489,10 +713,17 @@ class OrchestratorPlanner:
         context_packet_tokens = self._count_messages(
             [msg for msg in messages if _message_contains(msg, '<CONTEXT_PACKET>')]
         )
+        turn_context_tokens = self._count_messages(
+            [msg for msg in messages if is_turn_context_text(_message_text(msg))]
+        )
         tool_schema_tokens = self._count_tool_schema_tokens(tools)
         full_request_tokens = message_tokens + tool_schema_tokens
         dynamic_history_tokens = max(
-            0, message_tokens - static_prompt_tokens - context_packet_tokens
+            0,
+            message_tokens
+            - static_prompt_tokens
+            - context_packet_tokens
+            - turn_context_tokens,
         )
         usable_input = self._usable_input_tokens()
         return {
@@ -500,6 +731,7 @@ class OrchestratorPlanner:
             'tool_schema_tokens': tool_schema_tokens,
             'dynamic_history_tokens': dynamic_history_tokens,
             'context_packet_tokens': context_packet_tokens,
+            'turn_context_tokens': turn_context_tokens,
             'usable_input_tokens': usable_input,
             'full_request_tokens': full_request_tokens,
         }
@@ -617,16 +849,32 @@ class OrchestratorPlanner:
         When set, a single `<APP_DIRECTIVE>` block is inserted before the last
         user message.
         """
-        ts = getattr(state, 'turn_signals', None)
-        planning_directive = getattr(ts, 'planning_directive', None) if ts else None
-        if planning_directive is None:
-            extra_data = getattr(state, 'extra_data', {}) or {}
-            planning_directive = extra_data.get('planning_directive')
-
+        planning_directive = self._planning_directive(state)
         if not planning_directive:
             return messages
         status = f'<APP_DIRECTIVE>\n{planning_directive}\n</APP_DIRECTIVE>'
         return self._apply_control_message(messages, status)
+
+    @staticmethod
+    def _planning_directive(state: State) -> object:
+        ts = getattr(state, 'turn_signals', None)
+        planning_directive = getattr(ts, 'planning_directive', None) if ts else None
+        if planning_directive is None:
+            extra_data = getattr(state, 'extra_data', {}) or {}
+            if isinstance(extra_data, dict):
+                planning_directive = extra_data.get('planning_directive')
+        return planning_directive
+
+    def _inject_continuation_directive(self, messages: list, state: State) -> list:
+        """Append a newly raised directive without rewriting the user-turn prefix."""
+        planning_directive = self._planning_directive(state)
+        if not planning_directive:
+            return messages
+        status = wrap_turn_context(
+            f'<APP_DIRECTIVE>\n{planning_directive}\n</APP_DIRECTIVE>',
+            kind='continuation-control',
+        )
+        return [*messages, {'role': 'system', 'content': status}]
 
     def _inject_coding_preflight(self, messages: list, state: State, mode: str) -> list:
         """Inject a lightweight first-turn coding-task preflight when enabled."""
@@ -671,6 +919,7 @@ class OrchestratorPlanner:
 
     def _apply_control_message(self, messages: list, status: str) -> list:
         """Attach turn control either as a second system message or merged into primary."""
+        status = wrap_turn_context(status, kind='control')
         if getattr(self._config, 'merge_control_system_into_primary', False):
             return self._merge_control_into_primary_system(messages, status)
         return self._insert_control_message(messages, status)

--- a/backend/inference/caching/gemini_cache.py
+++ b/backend/inference/caching/gemini_cache.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import time
 from typing import TYPE_CHECKING, Any, cast
 
@@ -30,9 +31,24 @@ class GeminiCacheManager:
             cls._instance._caches = {}  # hash -> cache_name
         return cls._instance
 
-    def _get_hash(self, system_instruction: str | None, messages: list[dict]) -> str:
+    def _get_hash(
+        self,
+        system_instruction: str | None,
+        messages: list[dict],
+        *,
+        model: str = '',
+    ) -> str:
         """Create a stable hash of the context to identify existing caches."""
-        content = f'sys:{system_instruction or ""}|msgs:{str(messages)}'
+        content = json.dumps(
+            {
+                'model': model,
+                'system_instruction': system_instruction or '',
+                'messages': messages,
+            },
+            sort_keys=True,
+            separators=(',', ':'),
+            default=str,
+        )
         return hashlib.sha256(content.encode()).hexdigest()
 
     def get_or_create_cache(
@@ -59,7 +75,11 @@ class GeminiCacheManager:
         # We only use it if specifically requested via 'cache_prompt'
         # logic handled in the calling client.
 
-        content_hash = self._get_hash(system_instruction, messages)
+        content_hash = self._get_hash(
+            system_instruction,
+            messages,
+            model=model,
+        )
 
         # Check in-memory index first
         if content_hash in self._caches:
@@ -85,14 +105,19 @@ class GeminiCacheManager:
                     {'role': role, 'parts': [{'text': m.get('content', '')}]}
                 )
 
-            cache = cast(Any, client.caches.create)(
-                model=model,
-                config={
+            create_kwargs: dict[str, Any] = {
+                'model': model,
+                'config': {
                     'display_name': f'app_cache_{int(time.time())}',
                     'system_instruction': system_instruction,
                     'ttl': f'{ttl_minutes * 60}s',
                 },
-                contents=contents,
+            }
+            if contents:
+                create_kwargs['contents'] = contents
+
+            cache = cast(Any, client.caches.create)(
+                **create_kwargs,
             )
 
             logger.info(

--- a/backend/inference/caching/prompt_caching.py
+++ b/backend/inference/caching/prompt_caching.py
@@ -168,7 +168,12 @@ def should_mark_messages_for_prompt_cache(
     return mode in {PROMPT_CACHE_EXPLICIT_HINTS, PROMPT_CACHE_EXPLICIT_RESOURCE}
 
 
-def implicit_prompt_cache_key(entry: ModelEntry) -> str:
+def implicit_prompt_cache_key(
+    entry: ModelEntry,
+    *,
+    variant: str | None = None,
+) -> str:
     """Stable routing key for OpenAI-style implicit prompt caching."""
     model_id = runtime_model_id(entry)
-    return f'grinta:{entry.provider}:{model_id}'
+    base = f'grinta:{entry.provider}:{model_id}'
+    return f'{base}:{variant}' if variant else base

--- a/backend/inference/catalog/catalog_loader.py
+++ b/backend/inference/catalog/catalog_loader.py
@@ -1059,6 +1059,7 @@ def apply_model_param_overrides(
     *,
     provider: str | None = None,
     caching_prompt: bool = True,
+    prompt_cache_variant: str | None = None,
 ) -> dict:
     """Apply data-driven model-specific parameter overrides from the catalog."""
     entry = lookup(model)
@@ -1091,7 +1092,12 @@ def apply_model_param_overrides(
     if entry.supports_parallel_tool_calls and 'parallel_tool_calls' not in call_kwargs:
         call_kwargs['parallel_tool_calls'] = True
 
-    _apply_prompt_cache_call_kwargs(entry, call_kwargs, caching_prompt=caching_prompt)
+    _apply_prompt_cache_call_kwargs(
+        entry,
+        call_kwargs,
+        caching_prompt=caching_prompt,
+        prompt_cache_variant=prompt_cache_variant,
+    )
 
     return call_kwargs
 
@@ -1101,6 +1107,7 @@ def _apply_prompt_cache_call_kwargs(
     call_kwargs: dict,
     *,
     caching_prompt: bool,
+    prompt_cache_variant: str | None = None,
 ) -> None:
     if not caching_prompt or entry.prompt_cache_mode != 'implicit':
         return
@@ -1108,7 +1115,10 @@ def _apply_prompt_cache_call_kwargs(
         return
     from backend.inference.caching.prompt_caching import implicit_prompt_cache_key
 
-    call_kwargs['prompt_cache_key'] = implicit_prompt_cache_key(entry)
+    call_kwargs['prompt_cache_key'] = implicit_prompt_cache_key(
+        entry,
+        variant=prompt_cache_variant,
+    )
 
 
 def _apply_thinking_disabled(call_kwargs: dict, entry: ModelEntry) -> None:

--- a/backend/inference/llm/core.py
+++ b/backend/inference/llm/core.py
@@ -236,6 +236,7 @@ class LLM(RetryMixin, DebugMixin):
         ):
             kwargs.pop(param, None)
         prompt_accounting = kwargs.pop('_prompt_accounting', None)
+        prompt_cache_variant = kwargs.pop('_prompt_cache_variant', None)
         self._last_prompt_accounting = (
             prompt_accounting if isinstance(prompt_accounting, dict) else None
         )
@@ -280,6 +281,11 @@ class LLM(RetryMixin, DebugMixin):
             is_stream=is_stream,
             provider=getattr(self.config, 'custom_llm_provider', None),
             caching_prompt=bool(getattr(self.config, 'caching_prompt', True)),
+            prompt_cache_variant=(
+                prompt_cache_variant
+                if isinstance(prompt_cache_variant, str)
+                else None
+            ),
         )
 
         if self.config.seed is not None:

--- a/backend/inference/mappers/anthropic.py
+++ b/backend/inference/mappers/anthropic.py
@@ -3,6 +3,7 @@
 import json
 from typing import Any
 
+from backend.context.prompt.turn_context import split_stable_system_prefix
 from backend.core.logging.logger import app_logger as logger
 
 
@@ -65,8 +66,8 @@ def prepare_kwargs(
     messages: list[dict[str, Any]], kwargs: dict[str, Any], default_model: str
 ) -> tuple[list, dict[str, Any]]:
     """Extract system message and set model for Anthropic calls."""
-    system_msg = _collect_system_messages(messages)
-    filtered = _normalize_messages([m for m in messages if m['role'] != 'system'])
+    system_msg, body_messages = _split_system_messages(messages)
+    filtered = _normalize_messages(body_messages)
     if 'model' not in kwargs:
         kwargs['model'] = default_model
     if system_msg is not None:
@@ -96,16 +97,24 @@ def _content_to_text(content: Any) -> str:
     return '\n'.join(part for part in parts if part)
 
 
+def _split_system_messages(
+    messages: list[dict[str, Any]],
+) -> tuple[str | None, list[dict[str, Any]]]:
+    """Extract only the stable leading system prefix.
+
+    Anthropic exposes a top-level system field rather than mid-conversation
+    system roles. Late app-owned context is therefore retained as a marked user
+    block in its original turn position instead of being folded into (and
+    invalidating) the cached system prefix.
+    """
+    parts, body = split_stable_system_prefix(messages)
+    return ('\n\n'.join(parts) if parts else None), body
+
+
 def _collect_system_messages(messages: list[dict[str, Any]]) -> str | None:
-    """Combine all system messages for APIs that expose one system field."""
-    parts: list[str] = []
-    for message in messages:
-        if not isinstance(message, dict) or message.get('role') != 'system':
-            continue
-        text = _content_to_text(message.get('content')).strip()
-        if text:
-            parts.append(text)
-    return '\n\n'.join(parts) if parts else None
+    """Return the stable leading system prefix (backward-compatible helper)."""
+    system, _ = _split_system_messages(messages)
+    return system
 
 
 def _parse_tool_arguments(arguments: Any) -> dict[str, Any]:

--- a/backend/inference/mappers/gemini.py
+++ b/backend/inference/mappers/gemini.py
@@ -3,6 +3,8 @@
 import json
 from typing import Any
 
+from backend.context.prompt.turn_context import split_stable_system_prefix
+
 
 def _build_gemini_model_parts(
     text: str, tool_calls: list[dict[str, Any]] | None
@@ -80,12 +82,6 @@ def _resolve_content_text(
     return text, False
 
 
-def _accumulate_system_instruction(current: str | None, text: str) -> str:
-    if current:
-        return current + '\n\n' + text
-    return text
-
-
 def _build_tool_result_message(
     message: dict[str, Any], content: Any, content_text: str
 ) -> dict[str, Any]:
@@ -111,22 +107,22 @@ def convert_messages(
     Returns:
         (system_instruction_or_None, gemini_history_messages, caching_requested)
     """
-    system_instruction: str | None = None
+    system_parts, provider_messages = split_stable_system_prefix(messages)
+    system_instruction = '\n\n'.join(system_parts) if system_parts else None
     gemini_messages: list[dict[str, Any]] = []
     caching_requested = False
 
-    for m in messages:
+    # Cache hints may live on the leading system blocks removed above.
+    for original in messages:
+        _, msg_caching = _resolve_content_text(original.get('content', ''))
+        caching_requested = caching_requested or msg_caching
+
+    for m in provider_messages:
         content = m.get('content', '')
         role_name = m.get('role', 'user')
         content_text, msg_caching = _resolve_content_text(content)
         if msg_caching:
             caching_requested = True
-
-        if role_name == 'system':
-            system_instruction = _accumulate_system_instruction(
-                system_instruction, content_text
-            )
-            continue
 
         if role_name == 'tool':
             gemini_messages.append(_build_tool_result_message(m, content, content_text))

--- a/backend/inference/providers/anthropic_ops.py
+++ b/backend/inference/providers/anthropic_ops.py
@@ -237,15 +237,13 @@ def _prepare_anthropic_stream_request(
 ) -> tuple[list[dict[str, Any]], Any, dict[str, Any]]:
     from backend.inference.mappers.anthropic import (
         _apply_system_cache_control,
-        _collect_system_messages,
         _normalize_messages,
         _normalize_tools,
+        _split_system_messages,
     )
 
-    system_raw = _collect_system_messages(messages)
-    filtered_messages = _normalize_messages(
-        [message for message in messages if message['role'] != 'system']
-    )
+    system_raw, body_messages = _split_system_messages(messages)
+    filtered_messages = _normalize_messages(body_messages)
     request_kwargs = _apply_required_anthropic_request_defaults(client, kwargs)
     request_kwargs.setdefault('model', client.model_name)
     _normalize_tools(request_kwargs)

--- a/backend/inference/providers/gemini_ops.py
+++ b/backend/inference/providers/gemini_ops.py
@@ -71,22 +71,26 @@ class GeminiClient(DirectLLMClient):
         caching_requested: bool,
         model_name: str,
         system_instruction: str | None,
-        history_messages: list,
+        _history_messages: list,
     ) -> str | None:
-        """Get cache name if caching requested and there is content to cache."""
+        """Get a reusable cache for the stable system instruction only.
+
+        Growing chat history is sent through the normal chat request. Including
+        it in an explicit cache resource would create a new paid resource on
+        every turn instead of producing a cache hit.
+        """
         if not caching_requested:
             return None
         from backend.inference.caching.prompt_cache import get_prompt_cache
 
-        history_to_cache = history_messages if history_messages else []
-        if not history_to_cache and not system_instruction:
+        if not system_instruction:
             return None
         backend = get_prompt_cache('google')
         return backend.get_or_create_cache_handle(
             client=self.client,
             model=model_name,
             system_instruction=system_instruction,
-            messages=history_to_cache,
+            messages=[],
         )
 
     def _extract_gemini_text(self, message: dict[str, Any]) -> str:

--- a/backend/tests/unit/context/test_conversation_memory.py
+++ b/backend/tests/unit/context/test_conversation_memory.py
@@ -19,6 +19,7 @@ from backend.context.prompt.message_formatting import (
     message_with_text,
     remove_duplicate_system_prompt_user,
 )
+from backend.context.prompt.turn_context import is_turn_context_text
 from backend.core.message import Message, TextContent
 from backend.inference.tool_support.tool_result_format import decode_tool_result_payload
 from backend.integrations.mcp.mcp_utils import call_tool_mcp
@@ -126,12 +127,41 @@ class TestMcpUserAddendum:
 
         assert normalized[0].role == 'system'
         assert normalized[1].role == 'system'
-        assert (
-            extract_first_text(normalized[1])
-            == '<MCP_TOOLS>\n`github_search`\n</MCP_TOOLS>'
-        )
+        mcp_text = extract_first_text(normalized[1])
+        assert is_turn_context_text(mcp_text)
+        assert '<MCP_TOOLS>\n`github_search`\n</MCP_TOOLS>' in mcp_text
         assert normalized[2].role == 'user'
         assert extract_first_text(normalized[2]) == 'Implement the fix'
+
+    def test_dynamic_snapshots_do_not_modify_leading_system_prefix(self):
+        mem = _make_memory()
+        prompt_manager = cast(MagicMock, mem.prompt_manager)
+        prompt_manager.get_mcp_user_addendum.return_value = '<MCP_TOOLS>live</MCP_TOOLS>'
+        mem.get_context_summary = MagicMock(  # type: ignore[method-assign]
+            return_value='<SESSION_CONTEXT>now</SESSION_CONTEXT>'
+        )
+
+        normalized = mem._normalize_system_messages(
+            [_text_msg('user', 'Implement the fix')]
+        )
+
+        assert extract_first_text(normalized[0]) == (
+            'You are Grinta, an expert AI coding agent.'
+        )
+        assert [message.role for message in normalized] == [
+            'system',
+            'system',
+            'system',
+            'user',
+        ]
+        assert all(
+            is_turn_context_text(extract_first_text(message))
+            for message in normalized[1:3]
+        )
+        assert '<MCP_TOOLS>live</MCP_TOOLS>' in extract_first_text(normalized[1])
+        assert '<SESSION_CONTEXT>now</SESSION_CONTEXT>' in extract_first_text(
+            normalized[2]
+        )
 
 
 class TestToolResultPropagation:

--- a/backend/tests/unit/engine/orchestrator/test_memory_manager.py
+++ b/backend/tests/unit/engine/orchestrator/test_memory_manager.py
@@ -434,8 +434,9 @@ class TestBuildMessages:
         llm_config.model = 'claude-sonnet-4-6'
         llm_config.caching_prompt = True
 
-        m.build_messages([], MagicMock(), llm_config)
+        messages = m.build_messages([], MagicMock(), llm_config)
         assert tc.cache_prompt is True
+        assert messages[0].cache_enabled is True
 
     def test_sets_cache_prompt_on_last_user_message(self):
         from backend.core.message import Message, TextContent
@@ -455,8 +456,9 @@ class TestBuildMessages:
         llm_config.model = 'anthropic/claude-sonnet-4-6'
         llm_config.caching_prompt = True
 
-        m.build_messages([], MagicMock(), llm_config)
+        messages = m.build_messages([], MagicMock(), llm_config)
         assert user_tc.cache_prompt is True
+        assert messages[-1].cache_enabled is True
 
     def test_does_not_set_cache_prompt_for_openai_model(self):
         from backend.core.message import Message, TextContent

--- a/backend/tests/unit/engine/orchestrator/test_planner.py
+++ b/backend/tests/unit/engine/orchestrator/test_planner.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from backend.context.prompt.turn_context import wrap_turn_context
 from backend.engine.planner import (
     OrchestratorPlanner,
 )
@@ -473,6 +474,10 @@ class TestBuildLlmParams:
                     'content': '<RUNTIME_INFORMATION>repo</RUNTIME_INFORMATION>',
                 },
                 {'role': 'user', 'content': '<CONTEXT_PACKET>state</CONTEXT_PACKET>'},
+                {
+                    'role': 'system',
+                    'content': wrap_turn_context('Current mode: AGENT', kind='control'),
+                },
                 {'role': 'user', 'content': 'latest user task'},
             ],
             'tools': [
@@ -492,9 +497,151 @@ class TestBuildLlmParams:
         assert accounting['static_prompt_tokens'] > 0
         assert accounting['tool_schema_tokens'] > 0
         assert accounting['context_packet_tokens'] > 0
+        assert accounting['turn_context_tokens'] > 0
         assert accounting['dynamic_history_tokens'] > 0
         assert 100_000 < accounting['usable_input_tokens'] <= 120_000
         assert accounting['full_request_tokens'] > accounting['dynamic_history_tokens']
+
+    def test_prior_turn_context_is_restored_as_an_append_only_prefix(self):
+        p = _make_planner(
+            config=_make_config(enable_coding_preflight=False, enable_repo_map=False)
+        )
+        state = _make_state()
+        state.turn_signals.planning_directive = 'Inspect the auth boundary first.'
+
+        first_messages = [
+            {'role': 'system', 'content': 'stable system'},
+            {
+                'role': 'system',
+                'content': wrap_turn_context('MCP v1', kind='mcp-catalog'),
+            },
+            {'role': 'user', 'content': 'Fix auth'},
+        ]
+        with patch('backend.engine.planner.check_tools', return_value=[]):
+            first = p.build_llm_params(first_messages, state, [])
+
+        state.turn_signals.planning_directive = None
+        second_messages = [
+            {'role': 'system', 'content': 'stable system'},
+            {'role': 'user', 'content': 'Fix auth'},
+            {'role': 'assistant', 'content': 'I inspected it.'},
+            {
+                'role': 'system',
+                'content': wrap_turn_context('MCP v2', kind='mcp-catalog'),
+            },
+            {'role': 'user', 'content': 'Continue'},
+        ]
+        with patch('backend.engine.planner.check_tools', return_value=[]):
+            second = p.build_llm_params(second_messages, state, [])
+
+        first_request = first['messages']
+        second_request = second['messages']
+        assert second_request[: len(first_request)] == first_request
+        assert second_request[-1] == {'role': 'user', 'content': 'Continue'}
+        assert first['_prompt_cache_variant'] == second['_prompt_cache_variant']
+
+    def test_same_turn_retry_does_not_duplicate_context(self):
+        p = _make_planner(
+            config=_make_config(enable_coding_preflight=False, enable_repo_map=False)
+        )
+        state = _make_state()
+        messages = [
+            {'role': 'system', 'content': 'stable system'},
+            {'role': 'user', 'content': 'Retry this'},
+        ]
+
+        with patch('backend.engine.planner.check_tools', return_value=[]):
+            first = p.build_llm_params(messages, state, [])
+            retry = p.build_llm_params(messages, state, [])
+
+        assert retry['messages'] == first['messages']
+        context_blocks = [
+            message
+            for message in retry['messages']
+            if '<GRINTA_TURN_CONTEXT' in str(message.get('content', ''))
+        ]
+        assert len(context_blocks) == 1
+
+    def test_tool_loop_continuation_keeps_original_turn_prefix(self):
+        p = _make_planner(
+            config=_make_config(enable_coding_preflight=False, enable_repo_map=False)
+        )
+        state = _make_state()
+        messages = [
+            {'role': 'system', 'content': 'stable system'},
+            {'role': 'user', 'content': 'Inspect auth'},
+        ]
+
+        with patch('backend.engine.planner.check_tools', return_value=[]):
+            first = p.build_llm_params(messages, state, [])
+
+        continuation = [
+            *messages,
+            {'role': 'assistant', 'content': 'Calling read_file'},
+            {
+                'role': 'tool',
+                'name': 'read_file',
+                'tool_call_id': 'call-1',
+                'content': 'file contents',
+            },
+        ]
+        with patch('backend.engine.planner.check_tools', return_value=[]):
+            second = p.build_llm_params(continuation, state, [])
+
+        assert second['messages'][: len(first['messages'])] == first['messages']
+        assert second['messages'][-1]['role'] == 'tool'
+
+    def test_new_continuation_directive_is_appended_after_tool_history(self):
+        p = _make_planner(
+            config=_make_config(enable_coding_preflight=False, enable_repo_map=False)
+        )
+        state = _make_state()
+        messages = [
+            {'role': 'system', 'content': 'stable system'},
+            {'role': 'user', 'content': 'Inspect auth'},
+        ]
+        with patch('backend.engine.planner.check_tools', return_value=[]):
+            first = p.build_llm_params(messages, state, [])
+
+        state.turn_signals.planning_directive = 'Try a narrower search.'
+        continuation = [
+            *messages,
+            {'role': 'assistant', 'content': 'Calling grep'},
+            {'role': 'tool', 'content': 'no matches'},
+        ]
+        with patch('backend.engine.planner.check_tools', return_value=[]):
+            second = p.build_llm_params(continuation, state, [])
+
+        assert second['messages'][: len(first['messages'])] == first['messages']
+        assert second['messages'][-2]['role'] == 'tool'
+        assert second['messages'][-1]['role'] == 'system'
+        assert 'Try a narrower search.' in second['messages'][-1]['content']
+
+    def test_prompt_cache_variant_tracks_only_stable_prefix_and_tools(self):
+        p = _make_planner()
+        base = [
+            {'role': 'system', 'content': 'stable system'},
+            {
+                'role': 'system',
+                'content': wrap_turn_context('turn one', kind='control'),
+            },
+            {'role': 'user', 'content': 'task'},
+        ]
+        changed_tail = [
+            {'role': 'system', 'content': 'stable system'},
+            {
+                'role': 'system',
+                'content': wrap_turn_context('turn two', kind='control'),
+            },
+            {'role': 'user', 'content': 'different task'},
+        ]
+
+        assert p._build_prompt_cache_variant(base, []) == p._build_prompt_cache_variant(
+            changed_tail, []
+        )
+        assert p._build_prompt_cache_variant(base, []) != p._build_prompt_cache_variant(
+            [{'role': 'system', 'content': 'different system'}], []
+        )
 
     def test_injects_control_message_before_last_user(self):
         p = _make_planner()

--- a/backend/tests/unit/engine/test_message_serializer.py
+++ b/backend/tests/unit/engine/test_message_serializer.py
@@ -61,3 +61,21 @@ def test_serialize_messages_preserves_image_blocks():
         isinstance(part, dict) and part.get('type') == 'image_url'
         for part in out[0]['content']
     )
+
+
+def test_serialize_messages_preserves_prompt_cache_control():
+    msg = Message(
+        role='user',
+        cache_enabled=True,
+        content=[TextContent(text='stable anchor', cache_prompt=True)],
+    )
+
+    out = serialize_messages([msg])
+
+    assert out[0]['content'] == [
+        {
+            'type': 'text',
+            'text': 'stable anchor',
+            'cache_control': {'type': 'ephemeral'},
+        }
+    ]

--- a/backend/tests/unit/inference/test_gemini_cache.py
+++ b/backend/tests/unit/inference/test_gemini_cache.py
@@ -47,6 +47,11 @@ class TestGeminiCacheManager(unittest.TestCase):
         h2 = self.manager._get_hash(None, [{'role': 'user', 'content': 'y'}])
         self.assertNotEqual(h1, h2)
 
+    def test_hash_changes_with_model(self):
+        h1 = self.manager._get_hash('sys', [], model='gemini-a')
+        h2 = self.manager._get_hash('sys', [], model='gemini-b')
+        self.assertNotEqual(h1, h2)
+
     def test_hash_none_system(self):
         h = self.manager._get_hash(None, [])
         self.assertIsInstance(h, str)
@@ -180,8 +185,10 @@ class TestGeminiCacheManager(unittest.TestCase):
             system_instruction='test',
             messages=[],
         )
-        h = self.manager._get_hash('test', [])
+        h = self.manager._get_hash('test', [], model='gemini-1.5-pro')
         self.assertEqual(self.manager._caches[h], 'cache/stored')
+        call_kwargs = self.mock_client.caches.create.call_args.kwargs
+        self.assertNotIn('contents', call_kwargs)
 
     @patch('backend.inference.caching.gemini_cache.time')
     def test_default_ttl(self, mock_time):

--- a/backend/tests/unit/inference/test_llm.py
+++ b/backend/tests/unit/inference/test_llm.py
@@ -814,6 +814,7 @@ class TestGetCallKwargs:
             is_stream=True,
             provider=None,
             caching_prompt=True,
+            prompt_cache_variant=None,
         )
         mock_sanitize.assert_called_once_with(
             'google/gemini-2.5-pro', mock_apply_overrides.return_value

--- a/backend/tests/unit/inference/test_llm_direct_clients.py
+++ b/backend/tests/unit/inference/test_llm_direct_clients.py
@@ -349,7 +349,7 @@ class TestAnthropicClientHelpers:
         assert kwargs['system'] == 'Be helpful'
         assert kwargs['model'] == 'claude-3'
 
-    def test_prepare_kwargs_combines_all_system_messages(self):
+    def test_prepare_kwargs_combines_leading_system_messages(self):
         from backend.inference.mappers.anthropic import prepare_kwargs
 
         messages = [
@@ -362,6 +362,48 @@ class TestAnthropicClientHelpers:
 
         assert filtered == [{'role': 'user', 'content': 'What mode are you in?'}]
         assert kwargs['system'] == 'Base system prompt\n\nCurrent mode: PLAN'
+
+    def test_prepare_kwargs_keeps_late_system_context_in_turn_order(self):
+        from backend.inference.mappers.anthropic import prepare_kwargs
+
+        messages = [
+            {'role': 'system', 'content': 'Base system prompt'},
+            {'role': 'user', 'content': 'First task'},
+            {'role': 'assistant', 'content': 'First answer'},
+            {'role': 'system', 'content': 'Current mode: PLAN'},
+            {'role': 'user', 'content': 'Next task'},
+        ]
+
+        filtered, kwargs = prepare_kwargs(messages, {}, default_model='claude-3')
+
+        assert kwargs['system'] == 'Base system prompt'
+        assert [message['role'] for message in filtered] == [
+            'user',
+            'assistant',
+            'user',
+        ]
+        assert '<GRINTA_TURN_CONTEXT' in filtered[2]['content']
+        assert 'Current mode: PLAN' in filtered[2]['content']
+
+    def test_prepare_kwargs_does_not_promote_adjacent_turn_context(self):
+        from backend.context.prompt.turn_context import wrap_turn_context
+        from backend.inference.mappers.anthropic import prepare_kwargs
+
+        messages = [
+            {'role': 'system', 'content': 'Base system prompt'},
+            {
+                'role': 'system',
+                'content': wrap_turn_context('MCP snapshot', kind='mcp-catalog'),
+            },
+            {'role': 'user', 'content': 'First task'},
+        ]
+
+        filtered, kwargs = prepare_kwargs(messages, {}, default_model='claude-3')
+
+        assert kwargs['system'] == 'Base system prompt'
+        assert [message['role'] for message in filtered] == ['user']
+        assert 'MCP snapshot' in filtered[0]['content']
+        assert 'First task' in filtered[0]['content']
 
     def test_prepare_kwargs_converts_openai_tools_to_anthropic_schema(self):
         from backend.inference.mappers.anthropic import prepare_kwargs
@@ -802,6 +844,71 @@ class TestGeminiClientHelpers:
         assert gemini[0]['role'] == 'user'
         assert gemini[1]['role'] == 'model'
 
+    def test_convert_messages_keeps_late_system_context_out_of_instruction(self):
+        from backend.inference.mappers.gemini import convert_messages
+
+        messages = [
+            {'role': 'system', 'content': 'Stable system'},
+            {'role': 'user', 'content': 'First task'},
+            {'role': 'assistant', 'content': 'First answer'},
+            {'role': 'system', 'content': 'Current mode: PLAN'},
+            {'role': 'user', 'content': 'Next task'},
+        ]
+
+        system, gemini, _caching = convert_messages(messages)
+
+        assert system == 'Stable system'
+        assert [message['role'] for message in gemini] == [
+            'user',
+            'model',
+            'user',
+        ]
+        assert '<GRINTA_TURN_CONTEXT' in gemini[2]['parts'][0]['text']
+
+    def test_convert_messages_does_not_promote_adjacent_turn_context(self):
+        from backend.context.prompt.turn_context import wrap_turn_context
+        from backend.inference.mappers.gemini import convert_messages
+
+        messages = [
+            {'role': 'system', 'content': 'Stable system'},
+            {
+                'role': 'system',
+                'content': wrap_turn_context('MCP snapshot', kind='mcp-catalog'),
+            },
+            {'role': 'user', 'content': 'First task'},
+        ]
+
+        system, gemini, _caching = convert_messages(messages)
+
+        assert system == 'Stable system'
+        assert [message['role'] for message in gemini] == ['user']
+        assert 'MCP snapshot' in gemini[0]['parts'][0]['text']
+        assert 'First task' in gemini[0]['parts'][0]['text']
+
+    def test_gemini_explicit_cache_excludes_growing_history(self):
+        from backend.inference.clients import GeminiClient
+
+        client = GeminiClient.__new__(GeminiClient)
+        client.client = MagicMock()
+        cache_backend = MagicMock()
+        cache_backend.get_or_create_cache_handle.return_value = 'caches/stable'
+
+        with patch(
+            'backend.inference.caching.prompt_cache.get_prompt_cache',
+            return_value=cache_backend,
+        ):
+            cache_name = client._get_gemini_cache_name(
+                True,
+                'gemini-2.5-pro',
+                'Stable system',
+                [{'role': 'user', 'parts': [{'text': 'growing history'}]}],
+            )
+
+        assert cache_name == 'caches/stable'
+        assert (
+            cache_backend.get_or_create_cache_handle.call_args.kwargs['messages'] == []
+        )
+
     def test_extract_generation_config(self):
         from backend.inference.mappers.gemini import extract_generation_config
 
@@ -984,4 +1091,3 @@ class TestBoundedLlmHttpTimeout:
         assert isinstance(kwargs['timeout'], httpx.Timeout)
         assert kwargs['timeout'].read <= 30.0
         assert kwargs['timeout'].connect <= 10.0
-

--- a/backend/tests/unit/inference/test_prompt_caching.py
+++ b/backend/tests/unit/inference/test_prompt_caching.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from backend.inference.caching.prompt_caching import (
+    implicit_prompt_cache_key,
     model_supports_explicit_resource_cache,
     model_supports_prompt_cache_hints,
     model_uses_implicit_prompt_cache,
@@ -98,6 +99,24 @@ def test_apply_model_param_overrides_sets_prompt_cache_key_for_implicit() -> Non
         caching_prompt=False,
     )
     assert 'prompt_cache_key' not in disabled
+
+
+def test_implicit_prompt_cache_key_includes_stable_prefix_variant() -> None:
+    entry = lookup('gpt-5')
+    assert entry is not None
+
+    assert implicit_prompt_cache_key(entry, variant='abc123') == (
+        'grinta:openai:gpt-5:abc123'
+    )
+
+    out = apply_model_param_overrides(
+        'gpt-5',
+        {},
+        provider='openai',
+        caching_prompt=True,
+        prompt_cache_variant='abc123',
+    )
+    assert out['prompt_cache_key'] == 'grinta:openai:gpt-5:abc123'
 
 
 def test_strip_prompt_cache_hints_from_messages() -> None:


### PR DESCRIPTION
# Pull Request

## What and Why

Describe what changed and why this is needed.

## Risk Assessment

- Risk level: [ ] low [ ] medium [ ] high
- Security impact: [ ] none [ ] yes (describe below)
- Backward compatibility impact: [ ] none [ ] yes (describe below)

If any impact is "yes", explain:

## Test Evidence

List exact commands you ran and the result.

```text
# Example (matches required Linux/Windows gates):
uv run pytest backend/tests/unit -q
# Full tree (pytest.ini testpaths; slower, optional before merge):
# uv run pytest -q
uv run mypy --config-file mypy.ini
```

## Docs and Changelog

- [ ] Documentation updated (or not needed)
- [ ] `CHANGELOG.md` updated (or not needed)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / maintenance
- [ ] Security fix

## Related Issues

Fixes #(issue number)
Related to #(issue number)

## Summary by Sourcery

Stabilize provider prompt caching and turn-scoped context handling across conversations.

Enhancements:
- Persist and restore per-user-turn context snapshots alongside conversation history to keep continuation prompts append-only and avoid duplicating system context.
- Introduce turn-context markers and helpers so late system-derived context (MCP catalogs, session summaries, directives) is attached beside the active user turn instead of mutating the leading system prompt.
- Adjust Anthropic and Gemini mappers to extract only the stable leading system prefix while embedding turn-context blocks in the conversational body, preserving cacheability and role ordering.
- Include a prompt cache variant derived from the stable system prefix and active tools in LLM params and propagate it into catalog-driven model overrides and implicit prompt cache keys.
- Refine Gemini explicit cache hashing and creation to depend on model and stable system instructions only, excluding growing history and omitting empty contents.
- Update conversation memory normalization to insert MCP and session snapshots as wrapped system messages before the last user turn and keep a single static leading system message.
- Ensure message serialization preserves cache-control metadata and that prompt-cache hints mark both content parts and message-level cache flags.
- Extend prompt accounting to track tokens consumed by turn-context blocks separately from static prompt, context packets, and dynamic history.
- Clarify agent configuration around merging control system text into the primary system message and its impact on prompt cache reuse.

Tests:
- Add unit tests covering restoration of prior turn context, continuation behavior, and prompt cache variant stability for orchestrator planner prompts.
- Extend Anthropic and Gemini mapper tests to verify stable-prefix extraction, non-promotion of adjacent turn context, and correct placement of late system context in user turns.
- Add tests validating Gemini cache hashing by model, cache creation without contents for empty histories, and exclusion of growing history from explicit cache resources.
- Add tests for implicit prompt cache key variants, prompt cache control preservation in message serialization, and cache_prompt flags on first and last cacheable messages.
- Expand conversation memory tests to ensure MCP addenda and session snapshots are wrapped as turn context and do not alter the leading system prefix.