### PR TITLE
Align release documentation with public artifacts

### DIFF
--- a/.github/ISSUE_TEMPLATE/rc_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/rc_feedback.yml
@@ -50,9 +50,9 @@ body:
       label: Steps to reproduce (if applicable)
       description: Include commands, prompts, and sequence of actions.
       placeholder: |
-        1. pipx install grinta
-        2. grinta init
-        3. grinta
+        1. Clone the repository
+        2. Run pipx install -e .
+        3. Run grinta init, then grinta
         4. Ask it to ...
 
   - type: input
@@ -69,8 +69,8 @@ body:
     attributes:
       label: Installation path
       options:
-        - pipx install grinta
-        - Source (uv run python -m backend.cli.entry)
+        - Editable source install (pipx install -e .)
+        - Source runner (uv run python -m backend.cli.entry)
         - Docker
         - Other
     validations:

--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.12–3.13](https://img.shields.io/badge/Python-3.12--3.13-3776AB?logo=python&logoColor=white)](https://python.org)
-[![Install: pipx](https://img.shields.io/badge/install-pipx-brightgreen)](docs/QUICK_START.md)
+[![Install: source](https://img.shields.io/badge/install-from%20source-brightgreen)](docs/QUICK_START.md)
 [![mypy: checked](https://img.shields.io/badge/mypy-checked-2A6DB2.svg)](https://mypy-lang.org/)
 [![code style: Ruff](https://img.shields.io/badge/code%20style-ruff-261230.svg)](https://github.com/astral-sh/ruff)
 [![Tests](https://github.com/josephsenior/Grinta-Coding-Agent/actions/workflows/py-tests.yml/badge.svg)](https://github.com/josephsenior/Grinta-Coding-Agent/actions/workflows/py-tests.yml)
 [![Lint](https://github.com/josephsenior/Grinta-Coding-Agent/actions/workflows/lint.yml/badge.svg)](https://github.com/josephsenior/Grinta-Coding-Agent/actions/workflows/lint.yml)
 [![CLI Regression](https://github.com/josephsenior/Grinta-Coding-Agent/actions/workflows/e2e-tests.yml/badge.svg)](https://github.com/josephsenior/Grinta-Coding-Agent/actions/workflows/e2e-tests.yml)
-[![Release Stage: RC](https://img.shields.io/badge/release_stage-RC-orange)](https://github.com/josephsenior/Grinta-Coding-Agent/releases/tag/v1.0.0-rc1)
+[![Status: beta](https://img.shields.io/badge/status-beta-orange)](docs/RELEASE_CHECKLIST.md)
 
 > **Local-first. Provider-agnostic. Ships with real LSP + DAP. Optional extras stay opt-in.**
 >
 > A terminal coding agent that plans, executes, validates, and finishes — without a cloud control plane, without lock-in to one model vendor, and without the old heavyweight install footprint.
 >
-> **Current status:** `v1.0.0-rc1` public release candidate. Linux, Windows, and macOS run required unit and extended CI gates; smoke-install and onboarding validation are in place. Remaining GA work is mostly documentation alignment, contributor-doc honesty, and edge-case hardening after the post-rc1 decomposition wave.
+> **Current status:** active beta development toward the 1.0 release candidate. No GitHub release or PyPI package has been published yet; install from source using the tested paths below. Linux, Windows, and macOS run required unit and extended CI gates.
 
 Created and maintained by [Youssef Mejdi](https://github.com/josephsenior).
 
@@ -28,7 +28,8 @@ Direct link if the video does not load: [`docs/assets/grinta-demo.mp4`](docs/ass
 
 ## Release status
 
-- Latest public build is `v1.0.0-rc1` (release candidate), not final GA.
+- `main` currently identifies as `1.0.0rc1`, but no public release tag or PyPI package has been published yet.
+- Install from source until a signed release and its package artifacts are available.
 - Required CI covers sharded Linux unit coverage (75%), cross-platform unit gates, and integration/e2e/stress on Linux, Windows, and macOS; smoke-install and onboarding validation are in place for the current release line.
 - We are actively collecting feedback on UX clarity and edge-case reliability before the GA call.
 - Linux, Windows, and macOS are supported release targets, but certification depth differs by platform; see [docs/SUPPORT_MATRIX.md](docs/SUPPORT_MATRIX.md).
@@ -49,10 +50,12 @@ Grinta distinguishes itself by focusing on a completely local-first, provider-ag
 **Consumer, dev, Windows, WSL2, Linux, macOS:** [docs/QUICK_START.md](docs/QUICK_START.md)
 
 ```bash
-pipx install grinta    # consumer — then cd "<project>" && grinta
+git clone https://github.com/josephsenior/Grinta-Coding-Agent.git Grinta
+cd Grinta
+pipx install -e .
 ```
 
-Optional extras: `pipx install "grinta[rag]"` · `"grinta[browser]"` · `"grinta[all]"` — details in [Quick Start](docs/QUICK_START.md).
+Then run `grinta` from the project you want it to work on. Optional extras use the same source checkout: `pipx install -e ".[rag]"`, `pipx install -e ".[browser]"`, or `pipx install -e ".[all]"`. See the [Quick Start](docs/QUICK_START.md) for platform-specific bootstrap instructions.
 
 ## What you get
 

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -164,7 +164,7 @@ large local analysis pass, here is the assessment captured in this snapshot:
 
 ### What I Think (Honest Assessment):
 
-**This is sophisticated, production-ready software.** The architecture is sound, error handling is robust, and code quality is high.
+**This is substantial beta software.** The architecture is sound, error handling is robust, and code quality is high, but release and external-user validation remain in progress.
 
 **What's Excellent:**
 1. **Architecture**: Clean 3-layer design with proper separation
@@ -211,7 +211,7 @@ model is robust, and the local-first packaging approach is impressive.
 
 ## Final Verdict
 
-**Grinta is a well-architected, production-ready coding agent** with excellent separation of concerns, comprehensive testing, and good error handling. The main areas to address are file sizes and documentation. The RAG system is thoughtfully designed for its constraints (fast, lightweight, accurate enough).
+**Grinta is a well-architected beta coding agent** with strong separation of concerns, extensive testing, and good error handling. The main areas to address are file sizes, documentation, release validation, and broader external usage. The RAG system is thoughtfully designed for its constraints (fast, lightweight, accurate enough).
 
 **Rating Breakdown:**
 - Architecture: 9/10
@@ -221,4 +221,4 @@ model is robust, and the local-first packaging approach is impressive.
 - Performance: 9/10
 - Security: 8/10
 
-**Overall: 8.5/10** - Recommended for production use with minor improvements.
+**Overall: 8.5/10** - Recommended for evaluation and source-based testing while the release gates are completed.

--- a/docs/CONTRIBUTOR_MAP.md
+++ b/docs/CONTRIBUTOR_MAP.md
@@ -14,7 +14,7 @@ uv run python -m backend.cli.entry          # setup wizard on first launch if un
 PYTHONPATH=. uv run pytest backend/tests/unit -q
 ```
 
-Install path for end users: `pipx install grinta` → `grinta`. See [QUICK_START.md](QUICK_START.md).
+Current install path for end users: clone the repository, run `pipx install -e .`, then run `grinta`. See [QUICK_START.md](QUICK_START.md).
 Contributors should use `uv run` from a source checkout so dependencies stay isolated.
 
 ## Where to start by task

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -43,7 +43,7 @@ If you observe latencies meaningfully worse than p95 targets, investigate before
 
 ## Memory footprint
 
-Measured on a clean `pipx install grinta` base wheel (no `[rag]` / `[browser]` extras), Python 3.12, Linux x86_64:
+Measured on a clean base wheel built from the source checkout (no `[rag]` / `[browser]` extras), Python 3.12, Linux x86_64:
 
 - Idle REPL: ~150 MB RSS (target; run `ps` after launch to verify on your machine)
 - Base install on disk: ~400 MB under `~/.local/pipx/venvs/grinta` before optional extras (tree-sitter grammars dominate)

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1,224 +1,113 @@
 # Quick Start
 
-Install guide for all platforms (consumer, dev, Windows, WSL2, Linux, macOS).
+Grinta is currently distributed from source. A public GitHub release and PyPI package have not been published yet.
 
-**Paths:** only `<project>` is yours — the folder you want the agent to work in.  
-Clone the repo into a folder named `Grinta` (e.g. `~/Grinta` on WSL).
+The Grinta checkout and the project you want the agent to work on are different folders:
 
-Quote paths with spaces. First `grinta` runs setup — no `grinta init` required.
+- `Grinta` is this repository and contains the runtime and settings.
+- `<project>` is the repository or folder you want Grinta to modify.
 
-## Consumer vs dev
+Quote paths that contain spaces. Native Windows and WSL use separate installations and settings.
 
-| | **Consumer** | **Dev (source)** |
-| --- | --- | --- |
-| Install | `pipx install grinta` (PyPI) | `bash start_here.sh` or `.\START_HERE.ps1` once (bootstrap only) |
-| Settings | `~/.grinta/settings.json` | `Grinta/settings.json` in your clone |
-| Folders | `<project>` only | repo **and** `<project>` (often different) |
-| Daily command | `cd "<project>"` → `grinta` | See **Dev daily use** |
+## Fastest supported install
 
-`-p` — only when `<project>` is not your current directory.
+### Windows PowerShell
 
----
+```powershell
+git clone https://github.com/josephsenior/Grinta-Coding-Agent.git Grinta
+cd Grinta
+.\START_HERE.ps1
+```
 
-## Dev daily use (after bootstrap)
+The bootstrap installs the supported Python toolchain, synchronizes dependencies, runs the setup wizard and health checks, and installs the `grinta` command from the checkout.
 
-From inside your clone (`cd ~/Grinta` or `cd Grinta`):
+Then open the project you want Grinta to work on:
 
-### A. `grinta` on PATH (recommended)
-
-```bash
-pipx install -e .              # once, from repo root
+```powershell
 cd "<project>"
 grinta
 ```
 
-After big dependency changes: `pipx reinstall -e .` (from repo root).
+### Linux, macOS, or WSL
 
-### B. `uv run` (no global install)
+```bash
+git clone https://github.com/josephsenior/Grinta-Coding-Agent.git ~/Grinta
+cd ~/Grinta
+bash start_here.sh
+pipx install -e .
+```
 
-`uv run --directory` changes cwd to the Grinta clone — pass your project explicitly:
+Then:
+
+```bash
+cd "<project>"
+grinta
+```
+
+If you prefer not to install a global command, run from any project with:
+
+```bash
+cd "<project>"
+uv run --directory ~/Grinta grinta -p "$(pwd)"
+```
+
+## WSL notes
+
+Install and run Grinta inside Ubuntu, not PowerShell. Keep the Grinta checkout on the Linux filesystem for best performance:
+
+```bash
+git clone https://github.com/josephsenior/Grinta-Coding-Agent.git ~/Grinta
+```
+
+Your target project may remain under `/mnt/c`, although filesystem operations will be slower. A Windows path such as `C:\foo\bar` becomes `/mnt/c/foo/bar` in WSL.
+
+If required, install the basic WSL prerequisites first:
+
+```bash
+sudo apt update
+sudo apt install -y git pipx tmux
+pipx ensurepath
+```
+
+## Run directly from the checkout
+
+After bootstrap, you can avoid a global installation:
 
 ```bash
 cd "<project>"
 uv run --directory /path/to/Grinta grinta -p "$(pwd)"
 ```
 
-On WSL/Linux, Grinta also infers the project from your shell when you `cd` first (no `-p` needed in most cases).
-
-### C. Open `<project>` without `cd`
+Or provide the target explicitly:
 
 ```bash
 uv run --directory /path/to/Grinta grinta -p "<project>"
 ```
 
----
-
-## Windows (PowerShell)
-
-Native Windows and WSL are **separate installs** (different binaries, different `~/.grinta/`).
-
-### Consumer
+On Windows PowerShell:
 
 ```powershell
-pipx install grinta
-cd "<project>"
-grinta
+uv run --directory C:\path\to\Grinta grinta -p "C:\path\to\project"
 ```
 
-### Dev — bootstrap once
+## Optional features
 
-```powershell
-git clone https://github.com/josephsenior/Grinta-Coding-Agent.git Grinta
-cd Grinta
-.\START_HERE.ps1
-# START_HERE.ps1 will automatically install `grinta` globally via `uv tool install -e .`
-```
-
-Bootstrap does **not** open the TUI. Then:
-
-### Dev — every day
-
-```powershell
-cd "<project>"
-grinta
-# or: uv run --directory C:\path\to\Grinta grinta
-```
-
-### Shell tool (native Windows only)
-
-Default: Git Bash. For PowerShell in `settings.json`:
-
-```json
-"security": { "windows_shell": "powershell" }
-```
-
----
-
-## WSL (Ubuntu)
-
-Install and run Grinta **inside Ubuntu**, not PowerShell. Windows `pipx` does not apply.
-
-| Terminal | Install where |
-| --- | --- |
-| PowerShell / cmd / Git Bash | Windows (section above) |
-| Ubuntu / WSL | Inside WSL |
-
-**Dev layout:** clone to `~/Grinta`, not `/mnt/c`. `<project>` may be on `/mnt/c/...` (slower but OK).
-
-**Path conversion:** `C:\foo\bar` → `/mnt/c/foo/bar` (quote if spaces).
-
-**Preflight:** `grinta doctor` or `/health` in the TUI.
-
-### Consumer
+Install optional dependencies from the same checkout:
 
 ```bash
-sudo apt install -y python3.12 python3.12-venv pipx
-pipx ensurepath && source ~/.bashrc
-pipx install grinta
-grinta doctor
-cd "<project>"
-grinta
+pipx install -e ".[rag]"       # vector-memory support
+pipx install -e ".[browser]"   # browser tools
+pipx install -e ".[all]"       # all optional integrations
 ```
 
-### Dev — bootstrap once
+## Useful commands
 
-```bash
-git clone https://github.com/josephsenior/Grinta-Coding-Agent.git ~/Grinta
-cd ~/Grinta
-bash start_here.sh
-pipx install -e .    # optional
-```
+| Command | Purpose |
+|---|---|
+| `grinta init` | Create or update configuration |
+| `grinta doctor` | Check installation, settings, and WSL layout |
+| `grinta -p "<project>"` | Open a target without changing directory |
+| `grinta --help` | List CLI options |
+| `grinta --version` | Show the current source version |
 
-(Already have a copy on `/mnt/c`? `git clone /mnt/c/path/to/Grinta ~/Grinta` — then use the `~/` copy.)
-
-Bootstrap does **not** open the TUI. Then:
-
-### Dev — every day
-
-```bash
-cd "<project>"
-grinta
-# or: uv run --directory ~/Grinta grinta
-```
-
----
-
-## Linux
-
-### Consumer
-
-```bash
-pipx install grinta
-cd "<project>"
-grinta
-```
-
-### Dev — bootstrap once
-
-```bash
-git clone https://github.com/josephsenior/Grinta-Coding-Agent.git Grinta
-cd Grinta
-bash start_here.sh
-pipx install -e .
-```
-
-Bootstrap does **not** open the TUI. Then:
-
-### Dev — every day
-
-```bash
-cd "<project>"
-grinta
-```
-
----
-
-## macOS
-
-### Consumer (pipx)
-
-```bash
-pipx install grinta
-cd "<project>"
-grinta
-```
-
-### Consumer (Homebrew)
-
-```bash
-brew tap josephsenior/grinta https://github.com/josephsenior/Grinta-Coding-Agent
-brew install grinta
-cd "<project>"
-grinta
-```
-
-### Dev — bootstrap once
-
-```bash
-git clone https://github.com/josephsenior/Grinta-Coding-Agent.git Grinta
-cd Grinta
-bash start_here.sh
-pipx install -e .
-```
-
-Bootstrap does **not** open the TUI. Then:
-
-### Dev — every day
-
-```bash
-cd "<project>"
-grinta
-```
-
----
-
-## Optional
-
-| Command | When |
-| --- | --- |
-| `grinta init` | Reconfigure without TUI |
-| `grinta doctor` | Install / settings / WSL checks |
-| `grinta -p "<project>"` | Open project without `cd` first |
-| `pipx install "grinta[rag]"` | Vector memory extra |
-
-**Problems:** [TROUBLESHOOTING.md](TROUBLESHOOTING.md)
+For installation or startup problems, see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).

--- a/docs/RELEASE_NOTES_v1.0.0-rc1.md
+++ b/docs/RELEASE_NOTES_v1.0.0-rc1.md
@@ -1,14 +1,14 @@
-# Grinta v1.0.0-rc1 Release Notes
+# Proposed Grinta v1.0.0-rc1 Release Notes
 
-`v1.0.0-rc1` is the public release candidate for Grinta's 1.0 line.
-This build is intended for real usage and focused feedback before final GA.
+These notes are prepared for a future `v1.0.0-rc1` release. That tag and its package artifacts have not been published yet.
+The current `main` branch is intended for evaluation and focused feedback before the release candidate is cut.
 
-Historical note: these release notes capture the support stance at rc1 publication.
+These notes capture the intended support stance for RC publication.
 For the current support contract and CI certification depth, see [SUPPORT_MATRIX.md](SUPPORT_MATRIX.md).
 
 ## What this release is
 
-- Public RC for the CLI-first open-source product surface.
+- Proposed RC for the CLI-first open-source product surface.
 - Intended for everyday coding workflows on Linux and Windows while we collect final RC feedback.
 - Feedback-driven final polish phase before cutting `1.0.0`.
 
@@ -33,11 +33,11 @@ For the current support contract and CI certification depth, see [SUPPORT_MATRIX
 - Added clean-box smoke install scripts for Linux/macOS/Windows and Docker.
 - Clarified autonomy language to `conservative` / `balanced` / `full`.
 
-## Platform and support stance at rc1 publication
+## Intended platform and support stance at RC publication
 
 - **Supported:** Linux, Windows.
 - **Best effort:** macOS (advisory CI; not yet a required gate).
-- **Preferred install path:** `pipx install grinta`.
+- **Current install path:** editable installation from the source checkout.
 
 ## Known limitations and candid caveats
 
@@ -60,7 +60,9 @@ Please open issues with the `RC Feedback` template:
 ## Upgrade / install
 
 ```bash
-pipx install grinta
+git clone https://github.com/josephsenior/Grinta-Coding-Agent.git Grinta
+cd Grinta
+pipx install -e .
 grinta init
 grinta
 ```

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -57,10 +57,10 @@ active shell contract (`security.windows_shell` on Windows: `bash` vs `powershel
 
 | Method | Status | Notes |
 | --- | --- | --- |
-| `pipx install grinta` | Supported | Preferred for end users. |
-| Source (`uv run python -m backend.cli.entry`) | Supported | Preferred for contributors. |
+| Editable source install (`pipx install -e .`) | Supported | Current recommended installation path. |
+| Source (`uv run python -m backend.cli.entry`) | Supported | Recommended for contributors. |
 | Docker | Community / experimental | Container images may be available, but this repo does not provide an officially supported `docker compose` stack. |
-| Homebrew / Scoop | Supported | Community package managers, validated during release process. |
+| PyPI / Homebrew / Scoop | Planned | Enable only after matching public release artifacts are published and validated. |
 
 ## Product Surface
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -6,10 +6,10 @@ Install paths: [QUICK_START.md](QUICK_START.md).
 
 | Problem | Fix |
 | --- | --- |
-| `pipx` / `grinta` not found | Python 3.12+ → `pip install --user pipx` → `pipx ensurepath` → `pipx install grinta` |
+| `grinta` not found | From the Grinta source checkout, run `pipx install -e .`; see [QUICK_START.md](QUICK_START.md) |
 | `grinta` not found in WSL | Install inside Ubuntu, not Windows |
-| `uv` not found (dev) | `.\START_HERE.ps1` or `bash start_here.sh` |
-| Python 3.12+ (dev) | `uv python install 3.12` or re-run start script |
+| `uv` not found | `.\START_HERE.ps1` or `bash start_here.sh` |
+| Python 3.12+ | `uv python install 3.12` or re-run the start script |
 
 ## Startup
 

--- a/docs/onboarding_reports/2026-07-08_source_windows_2.md
+++ b/docs/onboarding_reports/2026-07-08_source_windows_2.md
@@ -25,7 +25,7 @@
 
 | Step | Pass / fail | Notes |
 | --- | --- | --- |
-| Install (`pipx install grinta` or source bootstrap) | pass | `python scripts/bootstrap_env.py base` |
+| Install (source bootstrap) | pass | `python scripts/bootstrap_env.py base` |
 | `grinta init` (interactive wizard) | pass | Non-interactive stdin correctly exits 3 without writing settings |
 | `grinta` TUI launch | skip | Automated smoke uses stub CLI task |
 | First agent task (`/health` or starter prompt) | pass | `scripts/smoke/run_stub_cli_task.ps1 -UseUvRun` |

--- a/docs/onboarding_reports/REPORT_TEMPLATE.md
+++ b/docs/onboarding_reports/REPORT_TEMPLATE.md
@@ -5,10 +5,10 @@
 | Field | Value |
 | --- | --- |
 | Date | YYYY-MM-DD |
-| Install path | pipx / source uv / docker |
+| Install path | editable source / source uv / docker |
 | OS | Linux / Windows / macOS / WSL2 Ubuntu + version |
 | Python version | |
-| Grinta version | `grinta --version` or PyPI tag |
+| Grinta version | `grinta --version` or commit SHA |
 | Machine | Fresh VM / hardware (no prior `~/.grinta`) |
 | Evidence type | `interactive-fresh-machine` or `ci-smoke-only` |
 | TTY for `grinta init` | yes / no (CI stubs = no) |
@@ -25,7 +25,7 @@
 
 | Step | Pass / fail | Notes |
 | --- | --- | --- |
-| Install (`pipx install grinta` or source bootstrap) | | |
+| Install (`pipx install -e .` or source bootstrap) | | |
 | `grinta init` (interactive wizard) | | |
 | `grinta` TUI launch | | |
 | First agent task (`/health` or starter prompt) | | |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,5 +298,6 @@ constraint-dependencies = [
 ]
 override-dependencies = [
   "aiohttp>=3.14.1",
+  "mcp>=1.28.1,<2",
   "pypdf>=6.12.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ version = "1.0.0rc1"
 description = "Local-first TUI/CLI coding agent"
 readme = "README.md"
 license = "MIT"
-authors = [ { name = "Joseph Senior" } ]
+authors = [ { name = "Youssef Mejdi" } ]
 requires-python = ">=3.12,<3.14"
 classifiers = [
   "Development Status :: 4 - Beta",

--- a/uv.lock
+++ b/uv.lock
@@ -13,6 +13,7 @@ constraints = [
 ]
 overrides = [
     { name = "aiohttp", specifier = ">=3.14.1" },
+    { name = "mcp", specifier = ">=1.28.1,<2" },
     { name = "pypdf", specifier = ">=6.12.0" },
 ]
 
@@ -2056,7 +2057,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2074,9 +2075,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

- replaces the broken RC release link with an accurate beta status
- documents that no GitHub release or PyPI distribution is currently public
- makes source installation the supported path across the README, quick start, support matrix, troubleshooting, and feedback template
- marks the prepared RC notes as proposed rather than published
- aligns package author metadata with Youssef Mejdi
- replaces unsupported production-readiness language with beta-stage language

## Why

The public documentation advertised a `v1.0.0-rc1` release and `pipx install grinta`, but neither the GitHub tag nor a PyPI distribution currently exists. The docs now describe what users can actually install and test.

## Validation

- `git diff --check`
- parsed `pyproject.toml` with Python `tomllib`
- verified local Markdown links in the README and quick-start guide
- confirmed `python -m pip index versions grinta` returns no public distribution

## Summary by Sourcery

Align public documentation and metadata with the current beta, source-only distribution status and unpublished v1.0.0-rc1 artifacts.

New Features:
- Document source-based installation as the primary supported path across README, Quick Start, support matrix, troubleshooting, contributor and onboarding docs.
- Clarify proposed v1.0.0-rc1 release notes, including intended platform stance and source-based upgrade instructions.

Enhancements:
- Update release status messaging from production-ready/RC language to beta-stage, evaluation-focused wording throughout the docs.
- Standardize installation examples, issue templates, and onboarding reports around editable installs from the repository and uv-based source runs.
- Refine troubleshooting and performance docs to reflect source-based installs and current tooling expectations.
- Update project author metadata to credit Youssef Mejdi and add an MCP dependency constraint in pyproject configuration.

Documentation:
- Revise README badges and status text to indicate beta development and lack of published GitHub/PyPI artifacts, pointing users to source installs.
- Simplify and rework QUICK_START to focus on cloning the repo, running the bootstrap scripts, and using grinta from the source checkout across platforms.
- Mark the v1.0.0-rc1 notes as proposed, not yet published, and adjust language around release stance and install methods.
- Update SUPPORT_MATRIX, CODE_REVIEW, CONTRIBUTOR_MAP, TROUBLESHOOTING, PERFORMANCE, and onboarding templates/reports to reflect current install paths and evaluation-focused usage expectations.