### PR TITLE
Upgrade MCP SDK past security advisories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,5 +298,6 @@ constraint-dependencies = [
 ]
 override-dependencies = [
   "aiohttp>=3.14.1",
+  "mcp>=1.28.1,<2",
   "pypdf>=6.12.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -13,6 +13,7 @@ constraints = [
 ]
 overrides = [
     { name = "aiohttp", specifier = ">=3.14.1" },
+    { name = "mcp", specifier = ">=1.28.1,<2" },
     { name = "pypdf", specifier = ">=6.12.0" },
 ]
 
@@ -2056,7 +2057,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2074,9 +2075,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

- upgrades `mcp` from 1.26.0 to 1.28.1
- adds a uv override so the optional `browser-use` dependency cannot force the vulnerable MCP version back into the lock
- leaves the existing browser-use and FastMCP versions unchanged

## Why

The previous lock triggered three high-severity Dependabot alerts:

- GHSA-vj7q-gjh5-988w
- GHSA-jpw9-pfvf-9f58
- GHSA-hvrp-rf83-w775

All three are patched by MCP 1.28.1. `browser-use` currently pins MCP 1.26.0 exactly, so the existing uv override mechanism is used to select the patched compatible SDK.

## Validation

- `uv lock --check`
- confirmed `uv tree --package mcp --depth 0` resolves MCP 1.28.1
- 176 focused MCP/config/reload tests passed

## Summary by Sourcery

Upgrade the MCP SDK to a secure version via dependency overrides to address recent security advisories.

Build:
- Add a uv override to constrain MCP to versions >=1.28.1,<2 in the dependency lock configuration.

Chores:
- Regenerate the uv.lock file to reflect the updated MCP dependency constraints.