### PR TITLE
Doctor checks uv encoding path

### DIFF
--- a/backend/cli/doctor/checks.py
+++ b/backend/cli/doctor/checks.py
@@ -328,8 +328,9 @@ def check_package_manager_path() -> DoctorCheck:
     full_path = os.environ.get('PATH', '')
     delimiter = os.pathsep
     paths = full_path.split(delimiter)
-    paths_normalized = [os.path.normcase(p) for p in paths]
-    target_normalized = os.path.normcase(target)
+    paths_normalized = [os.path.normcase(os.path.normpath(p)) for p in paths]
+    target_normalized = os.path.normcase(os.path.normpath(target))
+
     if target_normalized in paths_normalized:
         return DoctorCheck(
             'package_manager_path', True, f'{target} on PATH', critical=False

--- a/backend/cli/doctor/checks.py
+++ b/backend/cli/doctor/checks.py
@@ -255,6 +255,21 @@ def check_binary(name: str, *, critical: bool = True) -> DoctorCheck:
     return DoctorCheck(name, False, 'not found on PATH', critical=critical)
 
 
+def check_encoding() -> DoctorCheck:
+    encoding = sys.stdout.encoding
+    normalized = None
+    if encoding is not None:
+        normalized = encoding.lower().replace('-', '').replace('_', '')
+    if normalized == 'utf8':
+        return DoctorCheck('terminal_encoding', True, encoding, critical=False)
+    return DoctorCheck(
+        'terminal_encoding',
+        False,
+        f'found encoding: {encoding}; expected UTF-8 - set PYTHONUTF8=1',
+        critical=False,
+    )
+
+
 def check_optional_imports() -> DoctorCheck:
     script = (
         _repo_root() / 'backend' / 'scripts' / 'verify' / 'verify_optional_imports.py'
@@ -500,6 +515,7 @@ def collect_doctor_checks(*, verbose: bool = False) -> list[DoctorCheck]:
         check_binary('git'),
         check_binary('rg'),
         check_binary('uv', critical=False),
+        check_encoding(),
     ]
     if sys.platform.startswith('linux') or is_wsl_runtime():
         checks.append(check_binary('tmux'))
@@ -540,6 +556,7 @@ __all__ = [
     'DoctorCheck',
     'check_binary',
     'check_editing_stack',
+    'check_encoding',
     'check_execution_profile',
     'check_llm_config',
     'check_optional_imports',

--- a/backend/cli/doctor/checks.py
+++ b/backend/cli/doctor/checks.py
@@ -499,6 +499,7 @@ def collect_doctor_checks(*, verbose: bool = False) -> list[DoctorCheck]:
         check_execution_profile(),
         check_binary('git'),
         check_binary('rg'),
+        check_binary('uv', critical=False),
     ]
     if sys.platform.startswith('linux') or is_wsl_runtime():
         checks.append(check_binary('tmux'))

--- a/backend/cli/doctor/checks.py
+++ b/backend/cli/doctor/checks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import platform
 import shutil
 import subprocess
@@ -10,6 +11,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from backend.core.os_capabilities import is_linux, is_macos, is_windows
 
 
 @dataclass(frozen=True)
@@ -301,6 +304,41 @@ def check_optional_imports() -> DoctorCheck:
     return DoctorCheck('optional_imports', False, first, critical=False)
 
 
+def check_package_manager_path() -> DoctorCheck:
+    if is_windows():
+        target = Path.home() / 'scoop' / 'shims'
+        installed = target.exists()
+    elif is_macos() or is_linux():
+        prefixes = [
+            '/opt/homebrew/bin/brew',
+            '/usr/local/bin/brew',
+            '/home/linuxbrew/.linuxbrew/bin/brew',
+        ]
+        installed = False
+        for prefix in prefixes:
+            target = Path(prefix).parent
+            if Path(prefix).exists():
+                installed = True
+                break
+    else:
+        return DoctorCheck('package_manager_path', True, 'n/a', critical=False)
+    if not installed:
+        return DoctorCheck('package_manager_path', True, 'not detected', critical=False)
+
+    full_path = os.environ.get('PATH', '')
+    delimiter = os.pathsep
+    paths = full_path.split(delimiter)
+    paths_normalized = [os.path.normcase(p) for p in paths]
+    target_normalized = os.path.normcase(target)
+    if target_normalized in paths_normalized:
+        return DoctorCheck(
+            'package_manager_path', True, f'{target} on PATH', critical=False
+        )
+    return DoctorCheck(
+        'package_manager_path', False, f'{target} not on PATH', critical=False
+    )
+
+
 def check_editing_stack() -> DoctorCheck:
     from backend.engine.tools.health_check import run_production_health_check
 
@@ -516,6 +554,7 @@ def collect_doctor_checks(*, verbose: bool = False) -> list[DoctorCheck]:
         check_binary('rg'),
         check_binary('uv', critical=False),
         check_encoding(),
+        check_package_manager_path(),
     ]
     if sys.platform.startswith('linux') or is_wsl_runtime():
         checks.append(check_binary('tmux'))
@@ -560,6 +599,7 @@ __all__ = [
     'check_execution_profile',
     'check_llm_config',
     'check_optional_imports',
+    'check_package_manager_path',
     'check_platform',
     'check_python',
     'check_security_settings_values',

--- a/backend/cli/doctor/doctor_cli.py
+++ b/backend/cli/doctor/doctor_cli.py
@@ -19,6 +19,9 @@ from backend.cli.doctor.checks import (
     check_binary as _check_binary,
 )
 from backend.cli.doctor.checks import (
+    check_encoding as _check_encoding,
+)
+from backend.cli.doctor.checks import (
     check_llm_config as _check_llm_config,
 )
 from backend.cli.doctor.checks import (
@@ -122,6 +125,7 @@ def cmd_doctor(console: Console, *, verbose: bool = False) -> int:
 __all__ = [
     'DoctorCheck',
     '_check_binary',
+    '_check_encoding',
     '_check_llm_config',
     '_check_settings_schema',
     'collect_checks',

--- a/backend/cli/doctor/doctor_cli.py
+++ b/backend/cli/doctor/doctor_cli.py
@@ -25,6 +25,9 @@ from backend.cli.doctor.checks import (
     check_llm_config as _check_llm_config,
 )
 from backend.cli.doctor.checks import (
+    check_package_manager_path as _check_package_manager_path,
+)
+from backend.cli.doctor.checks import (
     check_settings_schema as _check_settings_schema,
 )
 from backend.cli.theme import (
@@ -127,6 +130,7 @@ __all__ = [
     '_check_binary',
     '_check_encoding',
     '_check_llm_config',
+    '_check_package_manager_path',
     '_check_settings_schema',
     'collect_checks',
     'cmd_doctor',

--- a/backend/tests/unit/cli/test_doctor_cli.py
+++ b/backend/tests/unit/cli/test_doctor_cli.py
@@ -25,7 +25,22 @@ def _quiet_console() -> Console:
 def test_collect_checks_includes_core_rows() -> None:
     checks = collect_checks()
     names = {check.name for check in checks}
-    assert {'version', 'python', 'platform', 'settings', 'llm', 'git', 'rg'} <= names
+    assert {
+        'version',
+        'python',
+        'platform',
+        'settings',
+        'llm',
+        'git',
+        'rg',
+        'uv',
+    } <= names
+
+
+def test_collect_checks_marks_uv_non_critical() -> None:
+    checks = collect_checks()
+    uv_check = next(check for check in checks if check.name == 'uv')
+    assert uv_check.critical is False
 
 
 def test_check_binary_found() -> None:

--- a/backend/tests/unit/cli/test_doctor_cli.py
+++ b/backend/tests/unit/cli/test_doctor_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from rich.console import Console
@@ -11,6 +12,7 @@ from rich.console import Console
 from backend.cli.doctor.doctor_cli import (
     DoctorCheck,
     _check_binary,
+    _check_encoding,
     _check_llm_config,
     _check_settings_schema,
     cmd_doctor,
@@ -34,6 +36,7 @@ def test_collect_checks_includes_core_rows() -> None:
         'git',
         'rg',
         'uv',
+        'terminal_encoding',
     } <= names
 
 
@@ -55,6 +58,24 @@ def test_check_binary_missing() -> None:
         check = _check_binary('rg')
     assert check.ok is False
     assert 'PATH' in check.detail
+
+
+def test_check_encoding_is_utf8() -> None:
+    with patch(
+        'backend.cli.doctor.checks.sys.stdout', SimpleNamespace(encoding='utf-8')
+    ):
+        check = _check_encoding()
+    assert check.ok is True
+    assert check.detail == 'utf-8'
+
+
+def test_check_encoding_is_not_utf8() -> None:
+    with patch(
+        'backend.cli.doctor.checks.sys.stdout', SimpleNamespace(encoding='cp1252')
+    ):
+        check = _check_encoding()
+    assert check.ok is False
+    assert 'cp1252' in check.detail
 
 
 def test_check_settings_schema_flags_nested_agent(tmp_path: Path, monkeypatch) -> None:

--- a/backend/tests/unit/cli/test_doctor_cli.py
+++ b/backend/tests/unit/cli/test_doctor_cli.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 from rich.console import Console
 
 from backend.cli.doctor.doctor_cli import (
@@ -14,10 +16,15 @@ from backend.cli.doctor.doctor_cli import (
     _check_binary,
     _check_encoding,
     _check_llm_config,
+    _check_package_manager_path,
     _check_settings_schema,
     cmd_doctor,
     collect_checks,
 )
+
+BREW_MAC = '/opt/homebrew/bin/brew'
+BREW_LINUX = '/home/linuxbrew/.linuxbrew/bin/brew'
+SCOOP_SHIMS = str(Path.home() / 'scoop' / 'shims')
 
 
 def _quiet_console() -> Console:
@@ -135,3 +142,65 @@ def test_check_llm_config_passes_for_local_provider_without_key(
 def test_verbose_collect_includes_editing_stack() -> None:
     checks = collect_checks(verbose=True)
     assert any(check.name == 'editing_stack' for check in checks)
+
+
+@pytest.mark.parametrize(
+    'os_name, exists_path, path_dirs, expected_ok, fragment',
+    [
+        (
+            'macos',
+            BREW_MAC,
+            ['/opt/homebrew/bin'],
+            True,
+            'on PATH',
+        ),  # on mac + brew installed + on path
+        (
+            'macos',
+            BREW_MAC,
+            ['/usr/bin'],
+            False,
+            'not on PATH',
+        ),  # on mac + brew installed + not on path
+        (
+            'linux',
+            BREW_LINUX,
+            ['/home/linuxbrew/.linuxbrew/bin'],
+            True,
+            'on PATH',
+        ),  # on linux + brew installed + on path
+        (
+            'windows',
+            SCOOP_SHIMS,
+            [SCOOP_SHIMS],
+            True,
+            'on PATH',
+        ),  # on windows + scoop installed + on path
+        (
+            'windows',
+            SCOOP_SHIMS,
+            ['C:/other'],
+            False,
+            'not on PATH',
+        ),  # on windows + scoop installed + not on path
+        ('macos', None, ['/usr/bin'], True, 'not detected'),  # on mac + not detected
+        ('other', None, [], True, 'n/a'),  # other os
+    ],
+)
+def test_package_manager_path(
+    monkeypatch, os_name, exists_path, path_dirs, expected_ok, fragment
+) -> None:
+    for name in ('is_windows', 'is_macos', 'is_linux'):
+        monkeypatch.setattr(
+            f'backend.cli.doctor.checks.{name}', lambda n=name: n == f'is_{os_name}'
+        )
+        monkeypatch.setattr(
+            'backend.cli.doctor.checks.Path.exists',
+            lambda self: (
+                str(self) == exists_path
+            ),  # None -> never matched -> not installed
+        )
+    monkeypatch.setenv('PATH', os.pathsep.join(path_dirs))
+
+    check = _check_package_manager_path()
+    assert check.ok is expected_ok
+    assert fragment in check.detail

--- a/backend/tests/unit/cli/test_doctor_cli.py
+++ b/backend/tests/unit/cli/test_doctor_cli.py
@@ -25,6 +25,7 @@ from backend.cli.doctor.doctor_cli import (
 BREW_MAC = '/opt/homebrew/bin/brew'
 BREW_LINUX = '/home/linuxbrew/.linuxbrew/bin/brew'
 SCOOP_SHIMS = str(Path.home() / 'scoop' / 'shims')
+BREW_INTEL = '/usr/local/bin/brew'
 
 
 def _quiet_console() -> Console:
@@ -44,6 +45,7 @@ def test_collect_checks_includes_core_rows() -> None:
         'rg',
         'uv',
         'terminal_encoding',
+        'package_manager_path',
     } <= names
 
 
@@ -182,6 +184,13 @@ def test_verbose_collect_includes_editing_stack() -> None:
             False,
             'not on PATH',
         ),  # on windows + scoop installed + not on path
+        (
+            'macos',
+            BREW_INTEL,
+            ['/usr/local/bin'],
+            True,
+            'on PATH',
+        ),  # intel mac homebrew
         ('macos', None, ['/usr/bin'], True, 'not detected'),  # on mac + not detected
         ('other', None, [], True, 'n/a'),  # other os
     ],


### PR DESCRIPTION
# Pull Request

## What and Why

Adds three environment checks to `grinta doctor` (`backend/cli/doctor/checks.py`): **uv availability**, **terminal UTF-8 encoding**, and **Scoop/Homebrew PATH**. They turn silent install failures into actionable messages — e.g. when a package manager is installed but its shims/bin dir isn't on PATH (the common Windows cause of "command not found"). All three are non-critical and independently testable. Windows CI runner and first-launch integration are intentionally left for a follow-up.

## Risk Assessment

- Risk level: [x] low [ ] medium [ ] high
- Security impact: [x] none [ ] yes
- Backward compatibility impact: [x] none [ ] yes

Additive only: new report rows in `collect_doctor_checks`; existing checks and behavior unchanged.

## Test Evidence

```text
PYTHONPATH=. uv run pytest backend/tests/unit/cli/test_doctor_cli.py -q
# 18 passed

PYTHONPATH=. uv run pytest backend/tests/unit/cli -q
# all passed (1 xfail)

uv run mypy --config-file mypy.ini backend/cli/doctor/checks.py backend/cli/doctor/doctor_cli.py backend/tests/unit/cli/test_doctor_cli.py
# Success: no issues found in 3 source files

uv run ruff check <files> && uv run ruff format --check <files>
# All checks passed / already formatted

# Full gate (enforced by CI): uv run pytest backend/tests/unit -q
```

## Docs and Changelog

- [x] Documentation updated (or not needed) — surfaced through `grinta doctor`, no doc change
- [x] `CHANGELOG.md` updated (or not needed)

## Type of Change

- [x] New feature

## Related Issues

Related to #91 (partial scope — commits use `Refs #91`; Windows CI runner and first-launch are follow-ups)

## Summary by Sourcery

Extend `grinta doctor` with additional non-critical environment diagnostics for CLI usability.

New Features:
- Add a doctor check for the presence of the `uv` binary and report it as non-critical.
- Add a doctor check that inspects terminal output encoding and warns when not using UTF-8.
- Add a doctor check that detects Scoop/Homebrew installations and verifies their shims/bin directory is on PATH.

Tests:
- Expand doctor CLI unit tests to cover the new encoding and package manager PATH checks and the uv check configuration.