### PR TITLE
Update logo width in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Grinta
 
 <p align="center">
-  <img src="docs/assets/logo.svg" alt="Grinta logo" width="280">
+  <img src="docs/assets/logo.svg" alt="Grinta logo" width="450">
 </p>
 
 ### A local-first autonomous coding agent built to finish long, failure-prone software tasks.


### PR DESCRIPTION
Increased logo width in README from 280 to 450 pixels.

# Pull Request

## What and Why

Describe what changed and why this is needed.

## Risk Assessment

- Risk level: [ ] low [ ] medium [ ] high
- Security impact: [ ] none [ ] yes (describe below)
- Backward compatibility impact: [ ] none [ ] yes (describe below)

If any impact is "yes", explain:

## Test Evidence

List exact commands you ran and the result.

```text
# Example (matches required Linux/Windows gates):
uv run pytest backend/tests/unit -q
# Full tree (pytest.ini testpaths; slower, optional before merge):
# uv run pytest -q
uv run mypy --config-file mypy.ini
```

## Docs and Changelog

- [ ] Documentation updated (or not needed)
- [ ] `CHANGELOG.md` updated (or not needed)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / maintenance
- [ ] Security fix

## Related Issues

Fixes #(issue number)
Related to #(issue number)

## Summary by Sourcery

Documentation:
- Update README logo width to use a larger rendered size.