### PR TITLE
fix(lsp): read1() on the session pipe so short frames are not held in the buffer

### DIFF
--- a/backend/tests/unit/utils/test_lsp_session_reader.py
+++ b/backend/tests/unit/utils/test_lsp_session_reader.py
@@ -1,0 +1,44 @@
+"""Regression tests for the persistent LSP session's pipe reader."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from backend.utils.http.stdio_json_rpc import encode_json_rpc_message
+from backend.utils.lsp.lsp_project_routing import LspFileContext
+from backend.utils.lsp.lsp_session import LspSession
+
+
+def test_lsp_session_reader_delivers_short_frame_without_waiting_for_eof(
+    tmp_path: Path,
+) -> None:
+    response = encode_json_rpc_message(
+        {
+            'jsonrpc': '2.0',
+            'id': 1,
+            'result': {'capabilities': {'referencesProvider': True}},
+        }
+    )
+    assert len(response) < 4096
+    ctx = LspFileContext(
+        server_name='fake-short-response',
+        command=(
+            sys.executable,
+            '-c',
+            (
+                'import sys, time; '
+                f'sys.stdout.buffer.write({response!r}); '
+                'sys.stdout.buffer.flush(); '
+                'time.sleep(5)'
+            ),
+        ),
+        language_id='python',
+        workspace_root=tmp_path,
+    )
+    session = LspSession(ctx)
+
+    try:
+        assert session.ensure_initialized(timeout=1.0) is True
+    finally:
+        session.close()

--- a/backend/utils/lsp/lsp_session.py
+++ b/backend/utils/lsp/lsp_session.py
@@ -173,8 +173,16 @@ class LspSession:
         if proc is None or proc.stdout is None:
             return
         try:
+            # Popen creates a BufferedReader by default.  Keep a read() fallback
+            # for file-like test doubles and unusual Popen configurations.
+            read_available = getattr(proc.stdout, 'read1', proc.stdout.read)
             while proc.poll() is None:
-                chunk = proc.stdout.read(4096)
+                # BufferedReader.read(size) tries to fill the whole requested
+                # buffer.  Language servers are long-lived, so a response shorter
+                # than 4096 bytes neither fills the buffer nor reaches EOF and the
+                # reader can block forever with a complete JSON-RPC frame waiting
+                # in the pipe.  read1() returns after one underlying pipe read.
+                chunk = read_available(4096)
                 if not chunk:
                     break
                 with self._lock:


### PR DESCRIPTION
## Summary

`LspSession._read_loop` reads the language server's stdout with `proc.stdout.read(4096)`.

`Popen` returns a `BufferedReader`, and `BufferedReader.read(size)` blocks until it can fill the whole requested buffer or the stream hits EOF. A language server is a long-lived process, so it never closes stdout.

When the server's reply is shorter than 4096 bytes, the reader blocks with a **complete JSON-RPC frame already sitting in the pipe**, while the server waits for the `initialized` notification that the client only sends after parsing the initialize response. Both sides wait on each other until the init timeout fires.

## Repro

Configure any stdio language server and run an `lsp` tool call:

```
lsp_query        LSP find_references on /path/to/file.js:88:10
lsp_query_result LSP unavailable — falling back to grep/search.
tool_result      {available: false, has_error: true, latency_ms: 20024, retryable: false}
```

Measured against `typescript-language-server` on a small JS workspace:

| frame | bytes |
| --- | --- |
| `window/logMessage` | 234 |
| initialize response (`id=1`) | 1,814 |
| **total before `initialized`** | **2,048** |

2,048 < 4096, so `read()` never returns. `latency_ms` lands exactly on the 20s `_DEFAULT_INIT_TIMEOUT_SEC`.

Meanwhile the server itself is healthy — driving the same binary directly over JSON-RPC from the same cwd answers `initialize` in **~0.1s**.

## Fix

```python
read_available = getattr(proc.stdout, 'read1', proc.stdout.read)
...
chunk = read_available(4096)
```

`read1()` returns after a single underlying pipe read, so a complete frame is delivered as soon as it arrives. The `getattr` keeps a `read()` fallback for file-like test doubles and unusual `Popen` configurations.

## Test plan

- [x] Adds `backend/tests/unit/utils/test_lsp_session_reader.py` — spawns a helper process that writes one short initialize response then sleeps, reproducing the deadlock.
- [x] The new test **fails on the unpatched reader** (`LSP initialize timed out`) and **passes with `read1()`** — verified by reverting the one-line change and re-running.
- [x] `pytest backend/tests/unit/utils` passes (54 LSP-related tests).
- [x] After the fix, real `lsp` tool calls return `LSP query completed.` and `find_references` yields correct line numbers instead of falling back to grep.

> The unrelated failures under `validation/`, `orchestration/`, and `cli/tui/` reproduce **identically on a clean `main`** in this environment (missing pytest plugins such as `pytest-trio`/`pytest-twisted`), so they are not regressions from this change.

## Summary by Sourcery

Prevent LSP session stdout reader from blocking indefinitely on short JSON-RPC frames by using a non-buffer-filling read method.

Enhancements:
- Improve LSP session stdout handling to work correctly with long-lived language server processes that emit small responses.

Tests:
- Add regression test ensuring the LSP session delivers short initialize responses promptly without waiting for EOF.