### PR TITLE
fix: align mcp dependency with fastmcp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
   "libtmux>=0.62,<0.63",
   # MCP protocol pinned to 1.x: Grinta's MCP code and error handling use the
   # 1.x API (McpError, Tool.input_schema) and fastmcp-slim requires mcp<2.0.
-  "mcp>=2.1.1,<3",
+  "mcp>=1.28.1,<2",
   "openai>=3.2,<4",
   "orjson>=3.12,<4",
   "pathspec>=1.1.1,<2",


### PR DESCRIPTION
## Summary

- align the direct `mcp` dependency with the documented 1.x API requirement
- restore compatibility with `fastmcp>=3.4.7,<4`, which requires `mcp<2`

## Verification

- `uv lock` resolves 231 packages successfully
- `uv sync` proceeds past the previous `mcp`/`fastmcp` resolver conflict
- full sync remains blocked locally by an unrelated network failure fetching the pinned `ShadowGit` dependency