### PR TITLE
test: expand local-model compatibility coverage

### DIFF
--- a/backend/engine/executor.py
+++ b/backend/engine/executor.py
@@ -309,6 +309,7 @@ class OrchestratorExecutor(
             tool_calls_list,
             state.streamed_usage,
             stream_response_id=self._ensure_stream_response_id(state),
+            finish_reason=state.finish_reason,
         )
         self._record_streaming_metrics(response, time.time())
         return response

--- a/backend/engine/executor_mixins/_executor_streaming_mixin.py
+++ b/backend/engine/executor_mixins/_executor_streaming_mixin.py
@@ -179,6 +179,15 @@ class _ExecutorStreamingMixin:
             state.stream_response_id = chunk_id.strip()
 
     @staticmethod
+    def _capture_stream_finish_reason(
+        state: _AsyncStreamingState,
+        choice: dict[str, Any],
+    ) -> None:
+        finish_reason = choice.get('finish_reason')
+        if isinstance(finish_reason, str) and finish_reason:
+            state.finish_reason = finish_reason
+
+    @staticmethod
     def _capture_fallback_response_id(
         state: _AsyncStreamingState,
         fallback: Any,
@@ -210,6 +219,7 @@ class _ExecutorStreamingMixin:
         streamed_usage: dict[str, int] | None,
         *,
         stream_response_id: str = '',
+        finish_reason: str = 'stop',
     ) -> Any:
         from backend.inference.clients import LLMResponse
 
@@ -228,7 +238,7 @@ class _ExecutorStreamingMixin:
             model=model_name,
             usage=resolved_usage,
             response_id=resolved_response_id,
-            finish_reason='stop',
+            finish_reason=finish_reason,
             tool_calls=tool_calls_list,
             reasoning_content=thinking_accum,
         )
@@ -312,6 +322,7 @@ class _ExecutorStreamingMixin:
 
         choices = first_chunk.get('choices', [])
         if choices:
+            self._capture_stream_finish_reason(state, choices[0])
             await self._process_stream_delta(
                 choices[0].get('delta', {}),
                 state,
@@ -362,6 +373,7 @@ class _ExecutorStreamingMixin:
                 if isinstance(chunk_usage, dict):
                     state.streamed_usage = chunk_usage
                 continue
+            self._capture_stream_finish_reason(state, choices[0])
             await self._process_stream_delta(
                 choices[0].get('delta', {}),
                 state,

--- a/backend/engine/executor_mixins/_executor_types.py
+++ b/backend/engine/executor_mixins/_executor_types.py
@@ -50,6 +50,7 @@ class _AsyncStreamingState:
     tool_calls_dict: dict[int, dict[str, Any]] = field(default_factory=dict)
     streamed_usage: dict[str, int] | None = None
     stream_response_id: str = ''
+    finish_reason: str = 'stop'
     in_inline_think_block: bool = False
     last_text_emit_at: float = 0.0
     last_text_emit_len: int = 0

--- a/backend/engine/planner.py
+++ b/backend/engine/planner.py
@@ -1003,6 +1003,9 @@ class OrchestratorPlanner:
 
     def _llm_supports_function_calling(self) -> bool:
         try:
+            native_tool_calling = getattr(self._llm.config, 'native_tool_calling', None)
+            if isinstance(native_tool_calling, bool):
+                return native_tool_calling
             model = (self._llm.config.model or '').strip()
             if not model:
                 return False

--- a/backend/tests/fixtures/local_models/lm_studio_mistral_stream.json
+++ b/backend/tests/fixtures/local_models/lm_studio_mistral_stream.json
@@ -1,0 +1,53 @@
+[
+  {
+    "id": "chatcmpl-lm-studio-mistral",
+    "object": "chat.completion.chunk",
+    "created": 1777996803,
+    "model": "mistral-7b-instruct",
+    "choices": [
+      {
+        "index": 0,
+        "delta": {"role": "assistant", "content": "The answer is "},
+        "finish_reason": null
+      }
+    ]
+  },
+  {
+    "id": "chatcmpl-lm-studio-mistral",
+    "object": "chat.completion.chunk",
+    "created": 1777996803,
+    "model": "mistral-7b-instruct",
+    "choices": [
+      {
+        "index": 0,
+        "delta": {"content": "truncated"},
+        "finish_reason": null
+      }
+    ]
+  },
+  {
+    "id": "chatcmpl-lm-studio-mistral",
+    "object": "chat.completion.chunk",
+    "created": 1777996803,
+    "model": "mistral-7b-instruct",
+    "choices": [
+      {
+        "index": 0,
+        "delta": {},
+        "finish_reason": "length"
+      }
+    ]
+  },
+  {
+    "id": "chatcmpl-lm-studio-mistral",
+    "object": "chat.completion.chunk",
+    "created": 1777996803,
+    "model": "mistral-7b-instruct",
+    "choices": [],
+    "usage": {
+      "prompt_tokens": 14,
+      "completion_tokens": 5,
+      "total_tokens": 19
+    }
+  }
+]

--- a/backend/tests/fixtures/local_models/ollama_codellama_truncated.json
+++ b/backend/tests/fixtures/local_models/ollama_codellama_truncated.json
@@ -1,0 +1,22 @@
+{
+  "id": "chatcmpl-ollama-codellama",
+  "object": "chat.completion",
+  "created": 1777996801,
+  "model": "codellama",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "def fibonacci(n):\n    if n < 2:\n        return n\n    return",
+        "tool_calls": null
+      },
+      "finish_reason": "length"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 22,
+    "completion_tokens": 16,
+    "total_tokens": 38
+  }
+}

--- a/backend/tests/fixtures/local_models/ollama_llama3_no_tools.json
+++ b/backend/tests/fixtures/local_models/ollama_llama3_no_tools.json
@@ -1,0 +1,22 @@
+{
+  "id": "chatcmpl-ollama-llama3",
+  "object": "chat.completion",
+  "created": 1777996800,
+  "model": "llama3",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "The repository contains a Python backend.",
+        "tool_calls": null
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 18,
+    "completion_tokens": 8,
+    "total_tokens": 26
+  }
+}

--- a/backend/tests/fixtures/local_models/ollama_mistral_tool_call.json
+++ b/backend/tests/fixtures/local_models/ollama_mistral_tool_call.json
@@ -1,0 +1,31 @@
+{
+  "id": "chatcmpl-ollama-mistral",
+  "object": "chat.completion",
+  "created": 1777996802,
+  "model": "mistral",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": null,
+        "tool_calls": [
+          {
+            "id": "call_local_1",
+            "type": "function",
+            "function": {
+              "name": "read_file",
+              "arguments": "{\"path\":\"README.md\"}"
+            }
+          }
+        ]
+      },
+      "finish_reason": "tool_calls"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 31,
+    "completion_tokens": 12,
+    "total_tokens": 43
+  }
+}

--- a/backend/tests/unit/inference/test_local_model_compatibility.py
+++ b/backend/tests/unit/inference/test_local_model_compatibility.py
@@ -1,0 +1,122 @@
+"""Compatibility tests for recorded Ollama and LM Studio responses."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from openai.types.chat import ChatCompletion
+
+from backend.engine.planner import OrchestratorPlanner
+from backend.inference.providers.openai_ops import (
+    _build_llm_response,
+    extract_openai_tool_calls,
+)
+
+FIXTURE_DIR = Path(__file__).parents[2] / 'fixtures' / 'local_models'
+
+
+def _load_fixture(name: str):
+    return json.loads((FIXTURE_DIR / name).read_text(encoding='utf-8'))
+
+
+def _parse_completion(name: str):
+    response = ChatCompletion.model_validate(_load_fixture(name))
+    client = SimpleNamespace(_extract_openai_tool_calls=extract_openai_tool_calls)
+    return _build_llm_response(response, client)
+
+
+@pytest.mark.parametrize(
+    ('fixture_name', 'finish_reason', 'has_tool_calls'),
+    [
+        ('ollama_llama3_no_tools.json', 'stop', False),
+        ('ollama_codellama_truncated.json', 'length', False),
+        ('ollama_mistral_tool_call.json', 'tool_calls', True),
+    ],
+)
+def test_ollama_openai_compatible_responses(
+    fixture_name: str,
+    finish_reason: str,
+    has_tool_calls: bool,
+) -> None:
+    response = _parse_completion(fixture_name)
+
+    assert response.finish_reason == finish_reason
+    assert bool(response.tool_calls) is has_tool_calls
+    assert response.usage['total_tokens'] > 0
+
+
+def test_explicitly_disabled_native_tools_use_text_fallback() -> None:
+    fixture = _load_fixture('ollama_llama3_no_tools.json')
+    llm = SimpleNamespace(
+        config=SimpleNamespace(
+            model=f'ollama/{fixture["model"]}',
+            native_tool_calling=False,
+        )
+    )
+    planner = OrchestratorPlanner(
+        config=SimpleNamespace(),
+        llm=llm,
+        safety_manager=MagicMock(),
+    )
+    tools = [
+        {
+            'type': 'function',
+            'function': {
+                'name': 'read_file',
+                'description': 'Read a file',
+                'parameters': {'type': 'object', 'properties': {}},
+            },
+        }
+    ]
+    params = planner._configure_tool_routing(
+        {'messages': [{'role': 'system', 'content': 'You are helpful.'}]},
+        tools,
+        [{'role': 'system', 'content': 'You are helpful.'}],
+        'auto',
+    )
+
+    assert 'tools' not in params
+    assert '<TOOL_CALL_FORMAT>' in params['messages'][0]['content']
+
+
+def test_lm_studio_stream_preserves_terminal_finish_reason(monkeypatch) -> None:
+    import backend.engine.function_calling.dispatch as function_calling
+    from backend.engine import executor as executor_module
+    from backend.engine.executor import OrchestratorExecutor
+
+    sys.modules.setdefault('app.engine.function_calling', function_calling)
+    monkeypatch.setattr(
+        executor_module.orchestrator_function_calling,
+        'response_to_actions',
+        lambda *_args, **_kwargs: [],
+    )
+    chunks = _load_fixture('lm_studio_mistral_stream.json')
+
+    async def fake_astream(**_kwargs):
+        for chunk in chunks:
+            yield chunk
+
+    llm = MagicMock()
+    llm.astream = fake_astream
+    llm.model = chunks[0]['model']
+    llm.config.model = f'lm-studio/{chunks[0]["model"]}'
+    safety_manager = MagicMock()
+    safety_manager.apply.side_effect = lambda _content, actions: (True, actions)
+    executor = OrchestratorExecutor(
+        llm=llm,
+        safety_manager=safety_manager,
+        planner=MagicMock(),
+        mcp_tools_provider=lambda: {},
+    )
+
+    result = asyncio.run(executor.async_execute({'messages': []}, None))
+
+    assert result.response.content == 'The answer is truncated'
+    assert result.response.finish_reason == 'length'
+    assert result.response.usage['total_tokens'] == 19

--- a/backend/tests/unit/inference/test_local_model_compatibility.py
+++ b/backend/tests/unit/inference/test_local_model_compatibility.py
@@ -105,7 +105,7 @@ def test_lm_studio_stream_preserves_terminal_finish_reason(monkeypatch) -> None:
     llm = MagicMock()
     llm.astream = fake_astream
     llm.model = chunks[0]['model']
-    llm.config.model = f'lm-studio/{chunks[0]["model"]}'
+    llm.config.model = f'lm_studio/{chunks[0]["model"]}'
     safety_manager = MagicMock()
     safety_manager.apply.side_effect = lambda _content, actions: (True, actions)
     executor = OrchestratorExecutor(

--- a/docs/LOCAL_MODELS.md
+++ b/docs/LOCAL_MODELS.md
@@ -1,0 +1,90 @@
+# Local models
+
+Grinta can use local models through an OpenAI-compatible HTTP endpoint. Ollama
+and LM Studio run the model; Grinta sends chat-completion requests and converts
+their responses into its provider-independent `LLMResponse` format.
+
+## Ollama
+
+1. Install Ollama, then start it with `ollama serve`.
+2. Download a model, for example `ollama pull llama3`.
+3. Set the following values in `settings.json`:
+
+```json
+{
+  "llm_provider": "ollama",
+  "llm_model": "ollama/llama3",
+  "llm_api_key": "${LLM_API_KEY}",
+  "llm_base_url": "http://localhost:11434/v1",
+  "llm_context_window_tokens": 8192,
+  "llm_max_output_tokens": 2048
+}
+```
+
+No API key is required for the default local Ollama server. If Ollama runs on a
+different host, replace `llm_base_url`; `OLLAMA_HOST` is also supported.
+
+## LM Studio
+
+1. Download a model in LM Studio.
+2. Load it and start LM Studio's local server.
+3. Copy the model identifier exposed by the server into `settings.json`:
+
+```json
+{
+  "llm_provider": "lm_studio",
+  "llm_model": "lm_studio/mistral-7b-instruct",
+  "llm_api_key": "${LLM_API_KEY}",
+  "llm_base_url": "http://localhost:1234/v1",
+  "llm_context_window_tokens": 8192,
+  "llm_max_output_tokens": 2048
+}
+```
+
+The model identifier must match the value returned by the server's `/v1/models`
+endpoint. Change the URL when LM Studio uses a non-default port.
+
+## Minimum model requirements
+
+- The server must implement OpenAI-compatible `/v1/models` and
+  `/v1/chat/completions` endpoints.
+- Configure the model's real context window. Grinta reserves 4,096 tokens for
+  output and protocol overhead, so an 8K context is a practical minimum for
+  small tasks; 16K or more is preferable for repository work.
+- Native tool calling is optional. Models without it use Grinta's text fallback,
+  but they must follow the injected tool syntax reliably to perform actions.
+- Streaming is optional. The same model must return at least one completion
+  choice in non-streaming mode.
+
+## Compatibility behavior
+
+- Non-streaming text, truncated responses, and OpenAI-style tool calls are
+  normalized through the same client used for hosted OpenAI-compatible APIs.
+- Streaming responses are accumulated into one final response. Grinta preserves
+  the terminal `finish_reason`, including `length` and `tool_calls`.
+- Setting `native_tool_calling` to `false` in an `LLMConfig` forces Grinta's text
+  tool-call fallback, even when the provider is generally tool-capable.
+
+## Limitations
+
+- Tool-call quality and schema compliance depend on the selected model. Some
+  local models only produce reliable plain text.
+- A `length` finish reason means the server stopped at its output limit; increase
+  the configured output limit or simplify the request before retrying.
+- A server that omits its terminal finish reason cannot distinguish truncation
+  from a normal stop.
+- The fixture tests validate protocol compatibility without downloading models
+  or starting Ollama or LM Studio. They do not benchmark model quality, latency,
+  memory use, or hardware support.
+
+## Contributor tests
+
+Recorded responses live in `backend/tests/fixtures/local_models`. Run them with:
+
+```bash
+PYTHONPATH=. uv run pytest backend/tests/unit/inference/test_local_model_compatibility.py
+```
+
+The existing Python CI inference shard runs `backend/tests/unit/inference` on
+every pull request, so these tests are automatically included without requiring
+a live local-model server.

--- a/docs/LOCAL_MODELS.md
+++ b/docs/LOCAL_MODELS.md
@@ -49,10 +49,12 @@ endpoint. Change the URL when LM Studio uses a non-default port.
 - The server must implement OpenAI-compatible `/v1/models` and
   `/v1/chat/completions` endpoints.
 - Configure the model's real context window. Grinta reserves 4,096 tokens for
-  output and protocol overhead, so an 8K context is a practical minimum for
-  small tasks; 16K or more is preferable for repository work.
-- Native tool calling is optional. Models without it use Grinta's text fallback,
-  but they must follow the injected tool syntax reliably to perform actions.
+  protocol overhead in addition to the output budget, so an 8K context is a
+  practical minimum for small tasks; 16K or more is preferable for repository
+  work.
+- Native tool calling is optional for plain-text responses. To perform actions,
+  the model must either support OpenAI-style tool calls or use Grinta's text
+  fallback and follow its injected tool syntax reliably.
 - Streaming is optional. The same model must return at least one completion
   choice in non-streaming mode.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ and `CODE_REVIEW.md` are point-in-time records and may describe an older tree.
 The Mermaid source (`grinta-deep-architecture.mmd`) is canonical for the deep
 architecture diagram; rendered SVG/PNG artifacts are refreshed separately.
 
-**Users:** [QUICK_START.md](QUICK_START.md) → [SETTINGS.md](SETTINGS.md) → [USER_GUIDE.md](USER_GUIDE.md)
+**Users:** [QUICK_START.md](QUICK_START.md) → [SETTINGS.md](SETTINGS.md) → [LOCAL_MODELS.md](LOCAL_MODELS.md) → [USER_GUIDE.md](USER_GUIDE.md)
 
 **Windows / WSL:** [QUICK_START.md](QUICK_START.md)
 


### PR DESCRIPTION
Closes #93

## Summary

- add four deterministic OpenAI-compatible JSON fixtures for Ollama and LM Studio
- cover plain responses, explicit no-native-tool fallback, truncated output, tool-call normalization, and streamed usage/finish metadata
- preserve terminal streaming `finish_reason` instead of always reporting `stop`
- respect explicit `native_tool_calling=false` in Planner routing
- document setup, minimum context/tool requirements, limits, and CI behavior in `docs/LOCAL_MODELS.md`

## CI coverage

The new tests live under `backend/tests/unit/inference`, which is already run by Python CI shard E on every pull request. No live local model, model download, or GPU is required.

## Verification

- focused compatibility and related routing/streaming suites: 161 passed
- full unit suite: 11,813 tests collected; exit code 0
- Ruff check and format check passed for changed Python files
- mypy passed for 1,810 source files
- `git diff --check` passed

The pytest run emitted existing cleanup warnings from permission-oriented filesystem tests; they did not affect the successful exit status.

## Summary by Sourcery

Expand local-model compatibility coverage and preserve provider response semantics across planning and streaming.

New Features:
- Add deterministic compatibility coverage for Ollama and LM Studio OpenAI-compatible responses, including text, truncation, tool calls, and streaming metadata.

Bug Fixes:
- Preserve terminal streaming finish reasons instead of always reporting stop.
- Honor explicit native_tool_calling=false settings when selecting planner tool routing.

Enhancements:
- Document local-model setup, compatibility behavior, requirements, limitations, and contributor test execution.

Documentation:
- Add local-model guidance to the documentation index and provide a dedicated local-model setup and compatibility guide.

Tests:
- Add recorded Ollama and LM Studio fixtures with unit tests covering response normalization, tool fallback, and streamed finish and usage metadata.